### PR TITLE
Make toolchain work under Archlinux

### DIFF
--- a/toolchain/configure.bzl
+++ b/toolchain/configure.bzl
@@ -51,7 +51,7 @@ def _download_llvm_preconfigured(rctx):
 
     exec_result = rctx.execute([
         "/usr/bin/env",
-        "python",
+        "python2",
         rctx.path(rctx.attr._llvm_release_name),
         llvm_version,
     ])

--- a/toolchain/llvm_release_name.py
+++ b/toolchain/llvm_release_name.py
@@ -61,6 +61,8 @@ def _linux(llvm_version):
         os_name = "linux-sles%s" % version
     elif distname == "ubuntu":
         os_name = "linux-gnu-ubuntu-%s" % version
+    elif distname == "arch":
+        os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian":
         os_name = "linux-gnu-debian%s" % version
     elif distname == "fedora":


### PR DESCRIPTION
The following changes were necessary to use the toolchain under Archlinux.

First, the autodetection script needs a case for Archlinux. Arch works with the current Ubuntu binaries, so not much work was necessary there.

Second, Archlinux links python -> python3 by default. This is not really according to the PEP, but that PEP came after the change and not much can be done here. Except, since this is really a Python 2 script, we should use `python2` instead of assuming the symlink python -> python2.