### PR TITLE
Add support for debian testing (this is the "head" debian release).

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -68,6 +68,8 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["arch", "ubuntu"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
+    elif distname == "debian" and version is None and major_llvm_version >= 7:
+        os_name = "linux-gnu-ubuntu-18.04"
     elif distname == "debian" and int(version) == 8 and major_llvm_version < 7:
         os_name = "linux-gnu-debian8"
     elif distname == "debian" and int(version) >= 9 and major_llvm_version >= 7:

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -68,12 +68,12 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["arch", "ubuntu"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
-    elif distname == "debian" and version is None and major_llvm_version >= 7:
+    elif distname == "debian" and (version is None or int(version) == 10):
         os_name = "linux-gnu-ubuntu-18.04"
+    elif distname == "debian" and int(version) == 9 and major_llvm_version >= 7:
+        os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and int(version) == 8 and major_llvm_version < 7:
         os_name = "linux-gnu-debian8"
-    elif distname == "debian" and int(version) >= 9 and major_llvm_version >= 7:
-        os_name = "linux-gnu-ubuntu-16.04"
     elif ((distname == "fedora" and int(version) >= 27) or
           (distname == "centos" and int(version) >= 7)) and major_llvm_version < 7:
         os_name = "linux-gnu-Fedora27"


### PR DESCRIPTION
this doesn't contain a version id and causes the python script to trace.

Example from debian:

PRETTY_NAME=“Debian GNU/Linux buster/sid”
NAME=“Debian GNU/Linux”
ID=debian
HOME_URL=“https://www.debian.org/”
SUPPORT_URL=“https://www.debian.org/support”
BUG_REPORT_URL=“https://bugs.debian.org/”

Based on this commit  it looks like the VERSION_ID maybe dropped
in future versions of debian?

https://metadata.ftp-master.debian.org/changelogs//main/b/base-files/base-files_11_changelog