### PR TITLE
toolchain/BUILD.tpl: add missing ':ar' dependency

### DIFF
--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -194,6 +194,7 @@ filegroup(
     srcs = [
         ":clang",
         ":ld",
+        ":ar",
         ":lib",
         ":sysroot_components",
     ],


### PR DESCRIPTION
When linking a static library, the following error could occur:

```
ERROR: BUILD.bazel:123:1: Linking of rule '//foo:libfoo' failed (Exit 1)
external/io_bazel/src/main/tools/process-wrapper-legacy.cc:58: "execvp(external/llvm_toolchain/bin/llvm-ar, ...)": No such file or directory
```

This was due to `:linker_components` missing a dependency on the `:ar` target.
This change add `:ar` to the `:linker_components` target.

Signed-off-by: Jason S. McMullan <jason.mcmullan@uber.com>