### PR TITLE
toolchain: on Fedora + CentOS, use the Ubuntu 18.04 clang

### DIFF
--- a/tests/scripts/fedora_test.sh
+++ b/tests/scripts/fedora_test.sh
@@ -29,7 +29,7 @@ set -exuo pipefail
 
 # Install dependencies
 dnf install -qy dnf-plugins-core
-dnf install -qy python gcc
+dnf install -qy python gcc ncurses-compat-libs
 
 # Run tests
 cd /src

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -82,8 +82,10 @@ def _linux(llvm_version):
     elif ((distname == "fedora" and int(version) >= 27) or
           (distname == "centos" and int(version) >= 7)) and major_llvm_version < 7:
         os_name = "linux-gnu-Fedora27"
-    elif distname in ["fedora", "centos"] and major_llvm_version >= 7:
+    elif distname == "centos" and major_llvm_version >= 7:
         os_name = "linux-gnu-ubuntu-16.04"
+    elif distname == "fedora" and major_llvm_version >= 7:
+        os_name = "linux-gnu-ubuntu-18.04"
     else:
         sys.exit("Unsupported linux distribution and version: %s, %s" % (distname, version))
 


### PR DESCRIPTION
I was hoping it would avoid errors I see on a Fedora host like:

```
external/llvm_toolchain/bin/clang: /lib64/libtinfo.so.5: no version information available (required by external/llvm_toolchain/bin/clang)
```

But it doesn't; however Fedora releases are much closer to 18.04
anyway, so I think this would be a good change anyway.