### PR TITLE
Adjust llvm download to use "darwin-apple" only when major_llvm_version == 9 (not >= 9)

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -22,7 +22,7 @@ def _major_llvm_version(llvm_version):
 
 def _darwin(llvm_version):
     major_llvm_version = _major_llvm_version(llvm_version)
-    suffix = "darwin-apple" if major_llvm_version >= 9 else "apple-darwin"
+    suffix = "darwin-apple" if major_llvm_version == 9 else "apple-darwin"
     return "clang+llvm-{llvm_version}-x86_64-{suffix}.tar.xz".format(
         llvm_version=llvm_version, suffix=suffix)
 


### PR DESCRIPTION
This PR made the following adjustment:

```
-    suffix = "darwin-apple" if major_llvm_version >= 9 else "apple-darwin"
+    suffix = "darwin-apple" if major_llvm_version == 9 else "apple-darwin"
```

The reason is that `LLVM 10.0.0` returnes back to `apple-darwin`:

```
"clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz": "94ebeb70f17b6384e052c47fef24a6d70d3d949ab27b6c83d4ab7b298278ad6f",

"clang+llvm-9.0.0-x86_64-darwin-apple.tar.xz": "b46e3fe3829d4eb30ad72993bf28c76b1e1f7e38509fbd44192a2ef7c0126fc7",

"clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz": "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>