### PR TITLE
Add Clang LLVM installation support on ubuntu 20.04

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -73,7 +73,7 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
     elif (distname == "ubuntu" and version.startswith("20")):
-+        os_name = "linux-gnu-ubuntu-18.04"
+        os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and (version is None or int(version) == 10):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -71,8 +71,8 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-14.04"
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         os_name = "linux-gnu-ubuntu-18.04"
-    # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
     elif (distname == "ubuntu" and version.startswith("20")):
+        # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -71,6 +71,9 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-14.04"
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         os_name = "linux-gnu-ubuntu-18.04"
+    # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
+    elif (distname == "ubuntu" and version.startswith("20")):
++        os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and (version is None or int(version) == 10):


### PR DESCRIPTION
**Summary**
This PR adds support for LLVM Clang installation on Ubuntu 20.04 using ubuntu 18.04 Clang releases.

**Test**

```
~/bazel-toolchain/toolchain/tools$ cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal

~/bazel-toolchain/toolchain/tools$ python llvm_release_name.py 10
clang+llvm-10-x86_64-linux-gnu-ubuntu-18.04.tar.xz
```
