### PR TITLE
Export files under bin/ and lib/

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -25,3 +25,12 @@ cc_test(
     srcs = ["stdlib_test.cc"],
     deps = [":stdlib"],
 )
+
+sh_test(
+    name = "file_dependency_test",
+    srcs = ["file_dependency_test.sh"],
+    data = [
+        "@llvm_toolchain//:bin/clang-format",
+        "@llvm_toolchain//:lib/libc++.a",
+    ],
+)

--- a/tests/file_dependency_test.sh
+++ b/tests/file_dependency_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+fail() {
+  >&2 echo "$@"
+  exit 1
+}
+
+[[ -a "external/llvm_toolchain/bin/clang-format" ]] || fail "bin/clang-format not found"
+
+[[ -a "external/llvm_toolchain/lib/libc++.a" ]] || fail "lib/libc++.a not found"
+
+echo "SUCCESS!"

--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -18,6 +18,9 @@ load("@rules_cc//cc:defs.bzl", "cc_toolchain_suite")
 
 exports_files(["Makevars"])
 
+# Some targets may need to directly depend on these files.
+exports_files(glob(["bin/*", "lib/*"]))
+
 filegroup(
     name = "empty",
     srcs = [],


### PR DESCRIPTION
This allows someone, for example, to depend on `lib/libclang.so`.

A good portion of these files are already implicitly exported, but that behaviour will be changing soon. See https://github.com/bazelbuild/bazel/issues/10225.