### PR TITLE
Run bazel migration tests separately

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,19 @@ jobs:
       env:
         BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
       run: tests/scripts/${{ matrix.script }}
+  migration_test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        script: [run_tests.sh, run_external_tests.sh]
+    steps:
+    - uses: actions/checkout@v2
+    - name: test
+      env:
+        BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
+        TEST_MIGRATION: true
+      run: tests/scripts/${{ matrix.script }}
   container_test:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -31,7 +31,7 @@ chmod a+x "${bazel}"
 
 # We exclude cc_libs_test from rules_go because it assumes that stdlibc++ has
 # been dynamically linked, but we link it statically on linux.
-"${bazel}" --bazelrc=/dev/null test \
+"${bazel}" ${TEST_MIGRATION+"--migrate"} --bazelrc=/dev/null test \
   --incompatible_enable_cc_toolchain_resolution \
   --symlink_prefix=/ \
   --color=yes \

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -42,7 +42,7 @@ chmod a+x "${bazel}"
 
 set -x
 "${bazel}" version
-"${bazel}" --migrate --bazelrc=/dev/null test \
+"${bazel}" ${TEST_MIGRATION+"--migrate"} --bazelrc=/dev/null test \
   --extra_toolchains="${toolchain_name}" \
   --incompatible_enable_cc_toolchain_resolution \
   --copt=-v \


### PR DESCRIPTION
This allows us to more easily identify the reason for test failures.