### PR TITLE
tools: use ID_LIKE if ID is not a known distro

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -17,6 +17,8 @@
 import platform
 import sys
 
+_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos"]
+
 def _major_llvm_version(llvm_version):
     return int(llvm_version.split(".")[0])
 
@@ -52,6 +54,12 @@ def _linux(llvm_version):
     if "ID" not in info:
         sys.exit("Could not find ID in /etc/os-release.")
     distname = info["ID"].strip('\"')
+
+    if distname not in _known_distros:
+        for distro in info["ID_LIKE"].strip('\"').split(' '):
+            if distro in known_distros:
+                distname = distro
+                break
 
     version = None
     if "VERSION_ID" in info:


### PR DESCRIPTION
From `man os-release`:

```
ID_LIKE=
A space-separated list of operating system identifiers in the same syntax as the ID= setting. It should list identifiers of operating systems that are closely related to the local operating system in regards to packaging and programming interfaces, for example listing one or more OS identifiers the local OS is a derivative from. An OS should generally only list other OS identifiers it itself is a derivative of, and not any OSes that are derived from it, though symmetric relationships are possible. Build scripts and similar should check this variable if they need to identify the local operating system and the value of ID= is not recognized. Operating systems should be listed in order of how closely the local operating system relates to the listed ones, starting with the closest. This field is optional. Example: for an operating system with "ID=centos", an assignment of "ID_LIKE="rhel fedora"" would be appropriate. For an operating system with "ID=ubuntu", an assignment of "ID_LIKE=debian" is appropriate.
```

On minor forks like KDE Neon (fork of Ubuntu 18.04), `distname` can be set to `Ubuntu` without issue. Assuming we want to do this for other forks also, we should make use of `ID_LIKE`.