### PR TITLE
llvm 11 support

### DIFF
--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -101,6 +101,14 @@ _llvm_distributions = {
     "clang+llvm-10.0.0-i386-unknown-freebsd11.tar.xz": "310ed47e957c226b0de17130711505366c225edbed65299ac2c3d59f9a59a41a",
     "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "b25f592a0c00686f03e3b7db68ca6dc87418f681f4ead4df4745a01d9be63843",
     "clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz": "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",
+
+    # 11.0.0
+    "clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "abfe77fa4c2ceda16455fac9dba58962af9173c5aa85d5bb8ca4f5165ef87a19",
+    "clang+llvm-11.0.0-x86_64-linux-sles12.4.tar.xz": "ce3e2e9788e0136f3082eb3199c6e2dd171f4e7c98310f83fc284c5ba734d27a",
+    "clang+llvm-11.0.0-sparcv9-sun-solaris2.11.tar.xz": "3f2bbbbd9aac9809bcc561d73b0db39ecd64fa099fac601f929da5e95a63bdc5",
+    "clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "829f5fb0ebda1d8716464394f97d5475d465ddc7bea2879c0601316b611ff6db",
+    "clang+llvm-11.0.0-amd64-pc-solaris2.11.tar.xz": "031699337d703fe42843a8326f94079fd67e46b60f25be5bdf47664e158e0b43",
+    "clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz": "b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -114,6 +122,7 @@ _llvm_distributions_base_url = {
     "8.0.1": "https://releases.llvm.org/",
     "9.0.0": "https://releases.llvm.org/",
     "10.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "11.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
 }
 
 def _python(rctx):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -78,9 +78,14 @@ def _linux(llvm_version):
     elif distname == "ubuntu" and version.startswith("14.04"):
         os_name = "linux-gnu-ubuntu-14.04"
     elif (distname == "ubuntu" and version.startswith("20.04")) or (distname == "linuxmint" and version.startswith("20")):
-        # There is no binary packages specifically for 20.04, but those for 18.04 works on
-        # 20.04
-        os_name = "linux-gnu-ubuntu-18.04"
+        if major_llvm_version < 11:
+            # There is no binary packages specifically for 20.04, but those for 18.04 works on
+            # 20.04
+            os_name = "linux-gnu-ubuntu-18.04"
+        else:
+            # release 11.0.0 started providing packaging for ubuntu 20
+            os_name = "linux-gnu-ubuntu-20.04"
+            
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         os_name = "linux-gnu-ubuntu-18.04"
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):

--- a/utils/llvm_checksums.sh
+++ b/utils/llvm_checksums.sh
@@ -44,9 +44,9 @@ github_host() {
   cd "${output_dir}"
   curl -s "https://api.github.com/repos/llvm/llvm-project/releases/tags/llvmorg-${llvm_version}" | \
     jq .assets[].browser_download_url | \
-    tee /Users/sbagaria/Downloads/urls.txt | \
+    tee ./urls.txt | \
     grep 'clang%2Bllvm.*tar.xz"$' | \
-    tee /Users/sbagaria/Downloads/filtered_urls.txt | \
+    tee ./filtered_urls.txt | \
     xargs -n1 curl -L -O
   )
 }


### PR DESCRIPTION
This change attempts to add support for the recently-released llvm 11 (see [here](https://github.com/llvm/llvm-project/releases)).

I've tested this manually on an ubuntu 20.04 VM and it seems to work, but I realize this is hardly complete testing. Lemme know if there's some other in-tree or automated testing I can run for this change.