### PR TITLE
python -> python3

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 The Bazel Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Ubuntu 20.04 does not include python on the PATH by default.

    ❯ which -a python
    python not found

    ❯ which -a python3
    /usr/bin/python3
    /bin/python3

Recent Python distributions all install the python3 binary.

This tool uses one python script (the one in this PR), and
it obviously assumes Python 3, because it uses `print(...)`
without `from __future__ import print_function`.

Would you accept a patch to hardcode `python3` in the shebang?
I'd really like to leave Python 2 behind, and there is too
much software in the world that assumes `python` means `python2`.