### PR TITLE
Work even if the repository is loaded under a different name

### DIFF
--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -86,7 +86,7 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
-load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "conditional_cc_toolchain")
+load("@%{parent_repo_name}//toolchain:rules.bzl", "conditional_cc_toolchain")
 
 conditional_cc_toolchain("cc-clang-linux", False, %{absolute_paths})
 conditional_cc_toolchain("cc-clang-darwin", True, %{absolute_paths})

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 load(
-    "@com_grail_bazel_toolchain//toolchain/internal:llvm_distributions.bzl",
+    "//toolchain/internal:llvm_distributions.bzl",
     _download_llvm = "download_llvm",
     _download_llvm_preconfigured = "download_llvm_preconfigured",
 )
 load(
-    "@com_grail_bazel_toolchain//toolchain/internal:sysroot.bzl",
+    "//toolchain/internal:sysroot.bzl",
     _sysroot_path = "sysroot_path",
 )
 load("@rules_cc//cc:defs.bzl", _cc_toolchain = "cc_toolchain")
@@ -54,6 +54,7 @@ def llvm_register_toolchains():
 
     sysroot_path, sysroot = _sysroot_path(rctx)
     substitutions = {
+        "%{parent_repo_name}": rctx.attr._llvm_release_name.workspace_name,
         "%{repo_name}": rctx.name,
         "%{llvm_version}": rctx.attr.llvm_version,
         "%{toolchain_path_prefix}": toolchain_path_prefix,
@@ -70,27 +71,27 @@ def llvm_register_toolchains():
 
     rctx.template(
         "toolchains.bzl",
-        Label("@com_grail_bazel_toolchain//toolchain:toolchains.bzl.tpl"),
+        Label("//toolchain:toolchains.bzl.tpl"),
         substitutions,
     )
     rctx.template(
         "cc_toolchain_config.bzl",
-        Label("@com_grail_bazel_toolchain//toolchain:cc_toolchain_config.bzl.tpl"),
+        Label("//toolchain:cc_toolchain_config.bzl.tpl"),
         substitutions,
     )
     rctx.template(
         "bin/cc_wrapper.sh",  # Co-located with the linker to help rules_go.
-        Label("@com_grail_bazel_toolchain//toolchain:cc_wrapper.sh.tpl"),
+        Label("//toolchain:cc_wrapper.sh.tpl"),
         substitutions,
     )
     rctx.template(
         "Makevars",
-        Label("@com_grail_bazel_toolchain//toolchain:Makevars.tpl"),
+        Label("//toolchain:Makevars.tpl"),
         substitutions,
     )
     rctx.template(
         "BUILD",
-        Label("@com_grail_bazel_toolchain//toolchain:BUILD.tpl"),
+        Label("//toolchain:BUILD.tpl"),
         substitutions,
     )
 

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@com_grail_bazel_toolchain//toolchain/internal:configure.bzl",
+    "//toolchain/internal:configure.bzl",
     _conditional_cc_toolchain = "conditional_cc_toolchain",
     _llvm_toolchain_impl = "llvm_toolchain_impl",
 )
@@ -56,7 +56,7 @@ llvm_toolchain = repository_rule(
             doc = "Use absolute paths in the toolchain. Avoids sandbox overhead.",
         ),
         "_llvm_release_name": attr.label(
-            default = "@com_grail_bazel_toolchain//toolchain/tools:llvm_release_name.py",
+            default = "//toolchain/tools:llvm_release_name.py",
             allow_single_file = True,
             doc = "Python module to output LLVM release name for the current OS.",
         ),


### PR DESCRIPTION
With this change, you can load the repository under a name other than "@com_grail_bazel_toolchain", for instance if you are using a forked version or just want to give it another name.

I'm not aware of any problems this causes.  Is it something you'd be willing to consider?