### PR TITLE
Factor the OS name normalization into one place

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -36,14 +36,15 @@ def _include_dirs_str(rctx, cpu):
         return ""
     return ("\n" + 12 * " ").join(["\"%s\"," % d for d in dirs])
 
+def _make_shortos(x):
+    if x == "linux":
+        return "linux"
+    elif x == "mac os x":
+        return "darwin"
+    fail("Unsupported OS: " + x)
+
 def llvm_toolchain_impl(rctx):
-    if rctx.os.name.startswith("windows"):
-        rctx.file("BUILD")
-        rctx.file("toolchains.bzl", """
-def llvm_register_toolchains():
-    pass
-        """)
-        return
+    shortos = _make_shortos(rctx.os.name)
 
     repo_path = str(rctx.path(""))
     relative_path_prefix = "external/%s/" % rctx.name
@@ -52,7 +53,7 @@ def llvm_register_toolchains():
     else:
         toolchain_path_prefix = relative_path_prefix
 
-    sysroot_path, sysroot = _sysroot_path(rctx)
+    sysroot_path, sysroot = _sysroot_path(rctx, shortos)
     substitutions = {
         "%{repo_name}": rctx.name,
         "%{llvm_version}": rctx.attr.llvm_version,
@@ -106,7 +107,7 @@ def llvm_register_toolchains():
         rctx.file("bin/ld.gold")
 
     # Repository implementation functions can be restarted, keep expensive ops at the end.
-    if not _download_llvm(rctx):
+    if not _download_llvm(rctx, shortos):
         _download_llvm_preconfigured(rctx)
 
 def conditional_cc_toolchain(name, darwin, absolute_paths = False):

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -193,17 +193,10 @@ def download_llvm_preconfigured(rctx):
 
 # Download LLVM from the user-provided URLs and return True. If URLs were not provided, return
 # False.
-def download_llvm(rctx):
-    if rctx.os.name == "linux":
-        urls = rctx.attr.urls.get("linux", default = [])
-        sha256 = rctx.attr.sha256.get("linux", default = "")
-        prefix = rctx.attr.strip_prefix.get("linux", default = "")
-    elif rctx.os.name == "mac os x":
-        urls = rctx.attr.urls.get("darwin", default = [])
-        sha256 = rctx.attr.sha256.get("darwin", default = "")
-        prefix = rctx.attr.strip_prefix.get("darwin", default = "")
-    else:
-        fail("Unsupported OS: " + rctx.os.name)
+def download_llvm(rctx, shortos):
+    urls = rctx.attr.urls.get(shortos, default = [])
+    sha256 = rctx.attr.sha256.get(shortos, default = "")
+    prefix = rctx.attr.strip_prefix.get(shortos, default = "")
 
     if not urls:
         return False

--- a/toolchain/internal/sysroot.bzl
+++ b/toolchain/internal/sysroot.bzl
@@ -30,13 +30,8 @@ def _default_sysroot(rctx):
         return ""
 
 # Return the sysroot path and the label to the files, if sysroot is not a system path.
-def sysroot_path(rctx):
-    if rctx.os.name == "linux":
-        sysroot = rctx.attr.sysroot.get("linux", default = "")
-    elif rctx.os.name == "mac os x":
-        sysroot = rctx.attr.sysroot.get("darwin", default = "")
-    else:
-        fail("Unsupported OS: " + rctx.os.name)
+def sysroot_path(rctx, shortos):
+    sysroot = rctx.attr.sysroot.get(shortos, default = "")
 
     if not sysroot:
         return (_default_sysroot(rctx), None)


### PR DESCRIPTION
Is this something you'd be willing to accept?  The only functional change is that you get an error slightly earlier on Windows, but otherwise it just de-duplicates the logic that is used to create the OS short name.