### PR TITLE
Support Debian releases with non-integer VERSION_ID

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -93,12 +93,18 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
-    elif distname == "debian" and (version is None or int(version) == 10):
-        os_name = "linux-gnu-ubuntu-18.04"
-    elif distname == "debian" and int(version) == 9 and major_llvm_version >= 7:
-        os_name = "linux-gnu-ubuntu-16.04"
-    elif distname == "debian" and int(version) == 8 and major_llvm_version < 7:
-        os_name = "linux-gnu-debian8"
+    elif distname == "debian":
+        int_version = None
+        try:
+            int_version = int(version)
+        except ValueError:
+            pass
+        if int_version is None or int_version == 10:
+            os_name = "linux-gnu-ubuntu-18.04"
+        elif int_version == 9 and major_llvm_version >= 7:
+            os_name = "linux-gnu-ubuntu-16.04"
+        elif int_version == 8 and major_llvm_version < 7:
+            os_name = "linux-gnu-debian8"
     elif ((distname == "fedora" and int(version) >= 27) or
           (distname == "centos" and int(version) >= 7)) and major_llvm_version < 7:
         os_name = "linux-gnu-Fedora27"


### PR DESCRIPTION
The systemd specification for the /etc/os-release file, where we pull the system version information from, specifies that the VERSION_ID field may contain characters in the range 0–9, a–z, ".", "_" and "-".  This commit fixes parsing for VERSION_ID fields that contain more than just the numeric digits 0–9.