### PR TITLE
Use `unix_cc_toolchain_config.bzl:cc_toolchain_config` from `@bazel_tools`.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,8 +87,6 @@ http_archive(
     urls = ["https://www.openssl.org/source/openssl-1.1.1c.tar.gz"],
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -13,158 +13,74 @@
 # limitations under the License.
 
 load(
-    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
-    "action_config",
-    "artifact_name_pattern",
-    "env_entry",
-    "env_set",
-    "feature",
-    "feature_set",
-    "flag_group",
-    "flag_set",
-    "make_variable",
-    "tool",
-    "tool_path",
-    "variable_with_value",
-    "with_feature_set",
+    "@bazel_tools//tools/cpp:unix_cc_toolchain_config.bzl",
+    unix_cc_toolchain_config = "cc_toolchain_config",
 )
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
-def _impl(ctx):
-    if (ctx.attr.cpu == "darwin"):
-        toolchain_identifier = "clang-darwin"
-    elif (ctx.attr.cpu == "k8"):
-        toolchain_identifier = "clang-k8-linux"
-    elif (ctx.attr.cpu == "aarch64"):
-        toolchain_identifier = "clang-aarch64-linux"
-    else:
+def cc_toolchain_config(name, cpu):
+    if not (cpu in ["aarch64", "darwin", "k8"]):
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "k8"):
-        host_system_name = "x86_64"
-    elif (ctx.attr.cpu == "aarch64"):
-        host_system_name = "aarch64"
-    elif (ctx.attr.cpu == "darwin"):
-        host_system_name = "x86_64-apple-macosx"
-    else:
-        fail("Unreachable")
+    # A bunch of variables that get passed straight through to
+    # `create_cc_toolchain_config_info`.
+    (toolchain_identifier, host_system_name, target_system_name, target_cpu,
+    target_libc, compiler, abi_version, abi_libc_version, builtin_sysroot) = {
+        "darwin": (
+            "clang-darwin",
+            "x86_64-apple-macosx",
+            "x86_64-apple-macosx",
+            "darwin",
+            "macosx",
+            "clang",
+            "darwin_x86_64",
+            "darwin_x86_64",
+            "%{sysroot_path}",
+        ),
+        "k8": (
+            "clang-k8-linux",
+            "x86_64",
+            "x86_64-unknown-linux-gnu",
+            "k8",
+            "glibc_unknown",
+            "clang",
+            "clang",
+            "glibc_unknown",
+            "%{sysroot_path}",
+        ),
+        "aarch64": (
+            "clang-aarch64-linux",
+            "aarch64",
+            "aarch64-unknown-linux-gnu",
+            "aarch64",
+            "glibc_unknown",
+            "clang",
+            "clang",
+            "glibc_unknown",
+            "%{sysroot_path}",
+        ),
+    }[cpu]
 
-    if (ctx.attr.cpu == "k8"):
-        target_system_name = "x86_64-unknown-linux-gnu"
-    elif (ctx.attr.cpu == "aarch64"):
-        target_system_name = "aarch64-unknown-linux-gnu"
-    elif (ctx.attr.cpu == "darwin"):
-        target_system_name = "x86_64-apple-macosx"
-    else:
-        fail("Unreachable")
 
-    if (ctx.attr.cpu == "darwin"):
-        target_cpu = "darwin"
-    elif (ctx.attr.cpu == "k8"):
-        target_cpu = "k8"
-    elif (ctx.attr.cpu == "aarch64"):
-        target_cpu = "aarch64"
-    else:
-        fail("Unreachable")
-
-    if (ctx.attr.cpu == "k8"):
-        target_libc = "glibc_unknown"
-    elif (ctx.attr.cpu == "aarch64"):
-        target_libc = "glibc_unknown"
-    elif (ctx.attr.cpu == "darwin"):
-        target_libc = "macosx"
-    else:
-        fail("Unreachable")
-
-    if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "aarch64" or
-        ctx.attr.cpu == "k8"):
-        compiler = "clang"
-    else:
-        fail("Unreachable")
-
-    if (ctx.attr.cpu == "k8"):
-        abi_version = "clang"
-    elif (ctx.attr.cpu == "aarch64"):
-        abi_version = "clang"
-    elif (ctx.attr.cpu == "darwin"):
-        abi_version = "darwin_x86_64"
-    else:
-        fail("Unreachable")
-
-    if (ctx.attr.cpu == "darwin"):
-        abi_libc_version = "darwin_x86_64"
-    elif (ctx.attr.cpu == "k8"):
-        abi_libc_version = "glibc_unknown"
-    elif (ctx.attr.cpu == "aarch64"):
-        abi_libc_version = "glibc_unknown"
-    else:
-        fail("Unreachable")
-
-    cc_target_os = None
-
-    if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "aarch64" or
-        ctx.attr.cpu == "k8"):
-        builtin_sysroot = "%{sysroot_path}"
-    else:
-        fail("Unreachable")
-
-    all_compile_actions = [
-        ACTION_NAMES.c_compile,
-        ACTION_NAMES.cpp_compile,
-        ACTION_NAMES.linkstamp_compile,
-        ACTION_NAMES.assemble,
-        ACTION_NAMES.preprocess_assemble,
-        ACTION_NAMES.cpp_header_parsing,
-        ACTION_NAMES.cpp_module_compile,
-        ACTION_NAMES.cpp_module_codegen,
-        ACTION_NAMES.clif_match,
-        ACTION_NAMES.lto_backend,
+    # Unfiltered compiler flags:
+    unfiltered_compile_flags = [
+        # Do not resolve our symlinked resource prefixes to real paths.
+        "-no-canonical-prefixes",
+        # Reproducibility
+        "-Wno-builtin-macro-redefined",
+        "-D__DATE__=\"redacted\"",
+        "-D__TIMESTAMP__=\"redacted\"",
+        "-D__TIME__=\"redacted\"",
+        "-fdebug-prefix-map=%{toolchain_path_prefix}=%{debug_toolchain_path_prefix}",
     ]
 
-    all_cpp_compile_actions = [
-        ACTION_NAMES.cpp_compile,
-        ACTION_NAMES.linkstamp_compile,
-        ACTION_NAMES.cpp_header_parsing,
-        ACTION_NAMES.cpp_module_compile,
-        ACTION_NAMES.cpp_module_codegen,
-        ACTION_NAMES.clif_match,
-    ]
 
-    preprocessor_compile_actions = [
-        ACTION_NAMES.c_compile,
-        ACTION_NAMES.cpp_compile,
-        ACTION_NAMES.linkstamp_compile,
-        ACTION_NAMES.preprocess_assemble,
-        ACTION_NAMES.cpp_header_parsing,
-        ACTION_NAMES.cpp_module_compile,
-        ACTION_NAMES.clif_match,
-    ]
-
-    codegen_compile_actions = [
-        ACTION_NAMES.c_compile,
-        ACTION_NAMES.cpp_compile,
-        ACTION_NAMES.linkstamp_compile,
-        ACTION_NAMES.assemble,
-        ACTION_NAMES.preprocess_assemble,
-        ACTION_NAMES.cpp_module_codegen,
-        ACTION_NAMES.lto_backend,
-    ]
-
-    all_link_actions = [
-        ACTION_NAMES.cpp_link_executable,
-        ACTION_NAMES.cpp_link_dynamic_library,
-        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-    ]
-
-    action_configs = []
-
-    if ctx.attr.cpu in ("k8", "aarch64"):
+    # Linker flags:
+    if cpu in ["k8", "aarch64"]:
         linker_flags = [
             # Use the lld linker.
             "-fuse-ld=lld",
-            # The linker has no way of knowing if there are C++ objects; so we always link C++ libraries.
+            # The linker has no way of knowing if there are C++ objects; so we
+            # always link C++ libraries.
             "-L%{toolchain_path_prefix}/lib",
             "-l:libc++.a",
             "-l:libc++abi.a",
@@ -179,9 +95,10 @@ def _impl(ctx):
             "-Wl,--hash-style=gnu",
             "-Wl,-z,relro,-z,now",
         ]
-    elif ctx.attr.cpu == "darwin":
+    elif cpu == "darwin":
         linker_flags = [
-            # Difficult to guess options to statically link C++ libraries with the macOS linker.
+            # Difficult to guess options to statically link C++ libraries with
+            # the macOS linker.
             "-lc++",
             "-lc++abi",
             "-headerpad_max_install_names",
@@ -191,352 +108,89 @@ def _impl(ctx):
     else:
         fail("Unreachable")
 
-    opt_feature = feature(name = "opt")
-    fastbuild_feature = feature(name = "fastbuild")
-    dbg_feature = feature(name = "dbg")
+    link_flags = [
+        "-lm",
+        "-no-canonical-prefixes",
+    ] + linker_flags
 
-    random_seed_feature = feature(name = "random_seed", enabled = True)
-    supports_pic_feature = feature(name = "supports_pic", enabled = True)
-    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
+    opt_link_flags = ["-Wl,--gc-sections"] if cpu in ["k8", "aarch64"] else []
 
-    unfiltered_compile_flags_feature = feature(
-        name = "unfiltered_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            # Do not resolve our smylinked resource prefixes to real paths.
-                            "-no-canonical-prefixes",
-                            # Reproducibility
-                            "-Wno-builtin-macro-redefined",
-                            "-D__DATE__=\"redacted\"",
-                            "-D__TIMESTAMP__=\"redacted\"",
-                            "-D__TIME__=\"redacted\"",
-                            "-fdebug-prefix-map=%{toolchain_path_prefix}=%{debug_toolchain_path_prefix}",
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
 
-    default_link_flags_feature = feature(
-        name = "default_link_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-lm",
-                            "-no-canonical-prefixes",
-                        ] + linker_flags,
-                    ),
-                ],
-            ),
-        ] + ([
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [flag_group(flags = ["-Wl,--gc-sections"])],
-                with_features = [with_feature_set(features = ["opt"])],
-            ),
-        ] if ctx.attr.cpu in ("k8", "aarch64") else []),
-    )
-
-    default_compile_flags_feature = feature(
-        name = "default_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            # Security
-                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
-                            "-fstack-protector",
-                            "-fno-omit-frame-pointer",
-                            # Diagnostics
-                            "-fcolor-diagnostics",
-                            "-Wall",
-                            "-Wthread-safety",
-                            "-Wself-assign",
-                        ],
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [flag_group(flags = ["-g", "-fstandalone-debug"])],
-                with_features = [with_feature_set(features = ["dbg"])],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-g0",
-                            "-O2",
-                            "-D_FORTIFY_SOURCE=1",
-                            "-DNDEBUG",
-                            "-ffunction-sections",
-                            "-fdata-sections",
-                        ],
-                    ),
-                ],
-                with_features = [with_feature_set(features = ["opt"])],
-            ),
-            flag_set(
-                actions = all_cpp_compile_actions,
-                flag_groups = [flag_group(flags = ["-std=c++17", "-stdlib=libc++"])],
-            ),
-        ],
-    )
-
-    objcopy_embed_flags_feature = feature(
-        name = "objcopy_embed_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = ["objcopy_embed_data"],
-                flag_groups = [flag_group(flags = ["-I", "binary"])],
-            ),
-        ],
-    )
-
-    user_compile_flags_feature = feature(
-        name = "user_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "user_compile_flags",
-                        flags = ["%{user_compile_flags}"],
-                        iterate_over = "user_compile_flags",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    sysroot_feature = feature(
-        name = "sysroot",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions + all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "sysroot",
-                        flags = ["--sysroot=%{sysroot}"],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    coverage_feature = feature(
-        name = "coverage",
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-fprofile-instr-generate", "-fcoverage-mapping"],
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [flag_group(flags = ["-fprofile-instr-generate"])],
-            ),
-        ],
-        provides = ["profile"],
-    )
-
-    framework_paths_feature = feature(
-        name = "framework_paths",
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.objc_compile,
-                    ACTION_NAMES.objcpp_compile,
-                    "objc-executable",
-                    "objc++-executable",
-                ],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-F%{framework_paths}"],
-                        iterate_over = "framework_paths",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    include_paths_feature = feature(
-        name = "include_paths",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = preprocessor_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["/I%{quote_include_paths}"],
-                        iterate_over = "quote_include_paths",
-                    ),
-                    flag_group(
-                        flags = ["/I%{include_paths}"],
-                        iterate_over = "include_paths",
-                    ),
-                    flag_group(
-                        flags = ["/I%{system_include_paths}"],
-                        iterate_over = "system_include_paths",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    dependency_file_feature = feature(
-        name = "dependency_file",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_compile,
-                    ACTION_NAMES.cpp_header_parsing,
-                ],
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "dependency_file",
-                        flags = ["/DEPENDENCY_FILE", "%{dependency_file}"],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    compiler_input_flags_feature = feature(
-        name = "compiler_input_flags",
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_compile,
-                    ACTION_NAMES.cpp_header_parsing,
-                    ACTION_NAMES.cpp_module_codegen,
-                ],
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "source_file",
-                        flags = ["/c", "%{source_file}"],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    compiler_output_flags_feature = feature(
-        name = "compiler_output_flags",
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.assemble],
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "output_file",
-                        expand_if_not_available = "output_assembly_file",
-                        flags = ["/Fo%{output_file}", "/Zi"],
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = [
-                    ACTION_NAMES.preprocess_assemble,
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_header_parsing,
-                    ACTION_NAMES.cpp_module_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                ],
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "output_file",
-                        expand_if_not_available = "output_assembly_file",
-                        flags = ["/Fo%{output_file}"],
-                    ),
-                    flag_group(
-                        expand_if_available = "output_file",
-                        flags = ["/Fa%{output_file}"],
-                    ),
-                    flag_group(
-                        expand_if_available = "output_file",
-                        flags = ["/P", "/Fi%{output_file}"],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    features = [
-        opt_feature,
-        fastbuild_feature,
-        dbg_feature,
-        random_seed_feature,
-        supports_pic_feature,
-        supports_dynamic_linker_feature,
-        unfiltered_compile_flags_feature,
-        default_link_flags_feature,
-        default_compile_flags_feature,
-        objcopy_embed_flags_feature,
-        user_compile_flags_feature,
-        sysroot_feature,
-        coverage_feature,
-        # Windows only features.
-        # input_paths_feature
-        # dependency_file_feature
-        # compiler_input_flags_feature
-        # compiler_output_flags_feature
+    # Default compiler flags:
+    compile_flags = [
+        # Security
+        "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
+        "-fstack-protector",
+        "-fno-omit-frame-pointer",
+        # Diagnostics
+        "-fcolor-diagnostics",
+        "-Wall",
+        "-Wthread-safety",
+        "-Wself-assign",
     ]
-    if (ctx.attr.cpu == "darwin"):
-        features.extend([framework_paths_feature])
 
+    dbg_compile_flags = ["-g", "-fstandalone-debug"]
+
+    opt_compile_flags = [
+        "-g0",
+        "-O2",
+        "-D_FORTIFY_SOURCE=1",
+        "-DNDEBUG",
+        "-ffunction-sections",
+        "-fdata-sections",
+    ]
+
+    cxx_flags = ["-std=c++17", "-stdlib=libc++"]
+
+
+    # Coverage flags:
+    coverage_compile_flags = ["-fprofile-instr-generate", "-fcoverage-mapping"]
+    coverage_link_flags = ["-fprofile-instr-generate"]
+
+
+    ## NOTE: framework paths is missing here; unix_cc_toolchain_config
+    ## doesn't seem to have a feature for this.
+
+
+    # C++ built-in include directories:
     cxx_builtin_include_directories = [
         "%{toolchain_path_prefix}include/c++/v1",
         "%{toolchain_path_prefix}lib/clang/%{llvm_version}/include",
         "%{toolchain_path_prefix}lib64/clang/%{llvm_version}/include",
     ]
-    if (ctx.attr.cpu in ["k8", "aarch64"]):
+
+    # If `builtin_sysroot` is supported, use the `sysroot_prefix` here.
+    # `builtin_sysroot` support – required to use the `%sysroot%` prefix – was
+    # only added in bazel v4.0.0.
+    #
+    # `native.bazel_version` might give us back an empty string if a local dev build
+    # of bazel is being used; in this case we'll assume the version is at least
+    # 4.0.0.
+    #
+    # See: https://github.com/bazelbuild/bazel/commit/da345f1f249ebf28bec88c6e0d63260dfaef14e9
+    builtin_sysroot_supported = int(("%{bazel_version}" or "4.0.0").split(".")[0]) >= 4
+    sysroot_for_include_dirs = "%{sysroot_prefix}" if builtin_sysroot_supported else builtin_sysroot
+    if not sysroot_for_include_dirs.endswith('/'):
+        sysroot_for_include_dirs += '/'
+
+    if (cpu in ["k8", "aarch64"]):
         cxx_builtin_include_directories += [
-            "%{sysroot_prefix}/include",
-            "%{sysroot_prefix}/usr/include",
-            "%{sysroot_prefix}/usr/local/include",
+            "{}include".format(sysroot_for_include_dirs),
+            "{}usr/include".format(sysroot_for_include_dirs),
+            "{}usr/local/include".format(sysroot_for_include_dirs),
         ]
-    if ctx.attr.cpu == "k8":
+    if (cpu == "k8"):
         cxx_builtin_include_directories += [
             %{k8_additional_cxx_builtin_include_directories}
         ]
-    elif ctx.attr.cpu == "aarch64":
+    elif (cpu == "aarch64"):
         cxx_builtin_include_directories += [
             %{aarch64_additional_cxx_builtin_include_directories}
         ]
-    elif (ctx.attr.cpu == "darwin"):
+    elif (cpu == "darwin"):
         cxx_builtin_include_directories += [
-            "%{sysroot_prefix}/usr/include",
-            "%{sysroot_prefix}/System/Library/Frameworks",
+            "{}usr/include".format(sysroot_for_include_dirs),
+            "{}System/Library/Frameworks".format(sysroot_for_include_dirs),
             "/Library/Frameworks",
         ] + [
             %{darwin_additional_cxx_builtin_include_directories}
@@ -544,136 +198,89 @@ def _impl(ctx):
     else:
         fail("Unreachable")
 
-    artifact_name_patterns = []
 
-    if (ctx.attr.cpu == "darwin"):
-        make_variables = [
-            make_variable(
-                name = "STACK_FRAME_UNLIMITED",
-                value = "-Wframe-larger-than=100000000 -Wno-vla",
-            ),
-        ]
-    elif (ctx.attr.cpu in ("k8", "aarch64")):
-        make_variables = []
-    else:
-        fail("Unreachable")
+    ## NOTE: make variables are missing here; unix_cc_toolchain_config doesn't
+    ## pass these to `create_cc_toolchain_config_info`.
 
-    if (ctx.attr.cpu in ("k8", "aarch64")):
-        tool_paths = [
-            tool_path(
-                name = "ld",
-                path = "%{tools_path_prefix}bin/ld.lld",
-            ),
-            tool_path(
-                name = "cpp",
-                path = "%{tools_path_prefix}bin/clang-cpp",
-            ),
-            tool_path(
-                name = "dwp",
-                path = "%{tools_path_prefix}bin/llvm-dwp",
-            ),
-            tool_path(
-                name = "gcov",
-                path = "%{tools_path_prefix}bin/llvm-profdata",
-            ),
-            tool_path(
-                name = "nm",
-                path = "%{tools_path_prefix}bin/llvm-nm",
-            ),
-            tool_path(
-                name = "objcopy",
-                path = "%{tools_path_prefix}bin/llvm-objcopy",
-            ),
-            tool_path(
-                name = "objdump",
-                path = "%{tools_path_prefix}bin/llvm-objdump",
-            ),
-            tool_path(name = "strip", path = "/usr/bin/strip"),
-            tool_path(
-                name = "gcc",
-                path = "%{tools_path_prefix}bin/clang",
-            ),
-            tool_path(
-                name = "ar",
-                path = "%{tools_path_prefix}bin/llvm-ar",
-            ),
-        ]
-    elif (ctx.attr.cpu == "darwin"):
-        tool_paths = [
-            tool_path(name = "ld", path = "%{tools_path_prefix}bin/ld"),
-            tool_path(
-                name = "cpp",
-                path = "%{tools_path_prefix}bin/clang-cpp",
-            ),
-            tool_path(
-                name = "dwp",
-                path = "%{tools_path_prefix}bin/llvm-dwp",
-            ),
-            tool_path(
-                name = "gcov",
-                path = "%{tools_path_prefix}bin/llvm-profdata",
-            ),
-            tool_path(
-                name = "nm",
-                path = "%{tools_path_prefix}bin/llvm-nm",
-            ),
-            tool_path(
-                name = "objcopy",
-                path = "%{tools_path_prefix}bin/llvm-objcopy",
-            ),
-            tool_path(
-                name = "objdump",
-                path = "%{tools_path_prefix}bin/llvm-objdump",
-            ),
-            tool_path(name = "strip", path = "/usr/bin/strip"),
-            tool_path(
-                name = "gcc",
-                path = "%{tools_path_prefix}bin/cc_wrapper.sh",
-            ),
-            tool_path(name = "ar", path = "/usr/bin/libtool"),
-        ]
-    else:
-        fail("Unreachable")
 
-    out = ctx.actions.declare_file(ctx.label.name)
-    ctx.actions.write(out, "Fake executable")
-    return [
-        cc_common.create_cc_toolchain_config_info(
-            ctx = ctx,
-            features = features,
-            action_configs = action_configs,
-            artifact_name_patterns = artifact_name_patterns,
-            cxx_builtin_include_directories = cxx_builtin_include_directories,
-            toolchain_identifier = toolchain_identifier,
-            host_system_name = host_system_name,
-            target_system_name = target_system_name,
-            target_cpu = target_cpu,
-            target_libc = target_libc,
-            compiler = compiler,
-            abi_version = abi_version,
-            abi_libc_version = abi_libc_version,
-            tool_paths = tool_paths,
-            make_variables = make_variables,
-            builtin_sysroot = builtin_sysroot,
-            cc_target_os = cc_target_os,
-        ),
-        DefaultInfo(
-            executable = out,
-        ),
-    ]
+    # Tool paths:
+    # `llvm-strip` was introduced in V7 (https://reviews.llvm.org/D46407):
+    llvm_version = "%{llvm_version}".split(".")
+    llvm_major_ver = int(llvm_version[0]) if len(llvm_version) else 0
+    strip_binary = \
+        "%{tools_path_prefix}bin/llvm-strip" if llvm_major_ver >= 7 else "/usr/bin/strip"
 
-cc_toolchain_config = rule(
-    attrs = {
-        "cpu": attr.string(
-            mandatory = True,
-            values = [
-                "darwin",
-                "k8",
-                "aarch64",
-            ],
-        ),
-    },
-    executable = True,
-    provides = [CcToolchainConfigInfo],
-    implementation = _impl,
-)
+    tool_paths = {
+        "cpp": "%{tools_path_prefix}bin/clang-cpp",
+        "dwp": "%{tools_path_prefix}bin/llvm-dwp",
+        "gcov": "%{tools_path_prefix}bin/llvm-profdata",
+        "llvm-cov": "%{tools_path_prefix}bin/llvm-cov",
+        "nm": "%{tools_path_prefix}bin/llvm-nm",
+        "objcopy": "%{tools_path_prefix}bin/llvm-objcopy",
+        "objdump": "%{tools_path_prefix}bin/llvm-objdump",
+        "strip": strip_binary,
+    }
+    tool_paths.update({
+        "k8": {
+            "ld": "%{tools_path_prefix}bin/ld.lld",
+            "gcc": "%{tools_path_prefix}bin/clang",
+            "ar": "%{tools_path_prefix}bin/llvm-ar",
+        },
+        "aarch64": {
+            "ld": "%{tools_path_prefix}bin/ld.lld",
+            "gcc": "%{tools_path_prefix}bin/clang",
+            "ar": "%{tools_path_prefix}bin/llvm-ar",
+        },
+        "darwin": {
+            # ld.lld Mach-O support is still experimental:
+            "ld": "%{tools_path_prefix}bin/ld",
+            # See `cc_wrapper.sh.tpl` for details:
+            "gcc": "%{tools_path_prefix}bin/cc_wrapper.sh",
+            # No idea why we use `libtool` instead of `llvm-ar` on macOS:
+            "ar": "/usr/bin/libtool",
+        },
+    }[cpu])
+
+
+    # Start-end group linker support:
+    # This was added to `lld` in this patch: http://reviews.llvm.org/D18814
+    #
+    # The oldest version of LLVM that we support is 6.0.0 which was released
+    # after the above patch was merged, so we just set this to `True` when `lld`
+    # is being used as the linker, which is always... except on macOS since
+    # `lld` Mach-O support is still experimental.
+    supports_start_end_lib = tool_paths["ld"].endswith("ld.lld")
+
+    # Additional arguments to cc_toolchain_config.
+    kwargs = {}
+    if builtin_sysroot_supported and builtin_sysroot:
+        # This was only added in bazel v4.0.0.
+        # See: https://github.com/bazelbuild/bazel/commit/da345f1f249ebf28bec88c6e0d63260dfaef14e9
+        kwargs.update(builtin_sysroot = builtin_sysroot)
+
+    # Source: https://cs.opensource.google/bazel/bazel/+/master:tools/cpp/unix_cc_toolchain_config.bzl
+    unix_cc_toolchain_config(
+        name = name,
+        cpu = target_cpu,
+        compiler = compiler,
+        toolchain_identifier = toolchain_identifier,
+        host_system_name = host_system_name,
+        target_system_name = target_system_name,
+        target_libc = target_libc,
+        abi_version = abi_version,
+        abi_libc_version = abi_libc_version,
+        cxx_builtin_include_directories = cxx_builtin_include_directories,
+        tool_paths = tool_paths,
+        compile_flags = compile_flags,
+        dbg_compile_flags = dbg_compile_flags,
+        opt_compile_flags = opt_compile_flags,
+        cxx_flags = cxx_flags,
+        link_flags = link_flags,
+        # link_libs = _,
+        opt_link_flags = opt_link_flags,
+        unfiltered_compile_flags = unfiltered_compile_flags,
+        coverage_compile_flags = coverage_compile_flags,
+        coverage_link_flags = coverage_link_flags,
+        supports_start_end_lib = supports_start_end_lib,
+        **kwargs,
+    )

--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -56,8 +56,19 @@ done
 if [[ "${PATH}:" == *"%{toolchain_path_prefix}bin:"* ]]; then
   # GoCompile sets the PATH to the directory containing the linker, and changes CWD.
   clang "$@"
-else
+elif [[ -f %{toolchain_path_prefix}bin/clang ]]; then
   %{toolchain_path_prefix}bin/clang "$@"
+else
+    # Some consumers of `CcToolchainConfigInfo`s will use a PWD that *isn't*
+    # the execroot (i.e. `cmake` from `rules_foreign_cc`). For cases like this,
+    # we'll try to find `clang` by assuming it's next to this script.
+    potential_clang_path="$(dirname "${0}")/clang"
+    if [[ -f ${potential_clang_path} ]]; then
+        "${potential_clang_path}" "${@}"
+    else
+        >&2 echo "ERROR: could not find clang; PWD is: $(pwd)."
+        exit 5
+    fi
 fi
 
 function get_library_path() {

--- a/toolchain/internal/sysroot.bzl
+++ b/toolchain/internal/sysroot.bzl
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 def _darwin_sdk_path(rctx):
-    if rctx.os.name != "mac os x":
-        return ""
-
     exec_result = rctx.execute(["/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx"])
     if exec_result.return_code:
         fail("Failed to detect OSX SDK path: \n%s\n%s" % (exec_result.stdout, exec_result.stderr))
@@ -23,8 +20,8 @@ def _darwin_sdk_path(rctx):
         print(exec_result.stderr)
     return exec_result.stdout.strip()
 
-def _default_sysroot(rctx):
-    if rctx.os.name == "mac os x":
+def _default_sysroot(rctx, shortos):
+    if shortos == "darwin":
         return _darwin_sdk_path(rctx)
     else:
         return ""
@@ -34,7 +31,7 @@ def sysroot_path(rctx, shortos):
     sysroot = rctx.attr.sysroot.get(shortos, default = "")
 
     if not sysroot:
-        return (_default_sysroot(rctx), None)
+        return (_default_sysroot(rctx, shortos), None)
 
     # If the sysroot is an absolute path, use it as-is. Check for things that
     # start with "/" and not "//" to identify absolute paths, but also support


### PR DESCRIPTION
A first pass at #23.

(I was trying to just copy over the bits needed to get LTO to work but it ended up being easier to just do #23).

---

This still needs to be tested and such but I thought I'd open a PR at this point to make sure the general approach here is okay.

A few things I should mention:
  - as the commit mentions, I had to turn `cc_toolchain_config` into a macro so that it could call the `unix_cc_toolchain_config.bzl:cc_toolchain_config` rule
    + this was surprisingly hassle free!
    + this also means that we _could_ just inline everything in `cc_toolchain_config.bzl.tpl` right into `BUILD.tpl` but there isn't really a reason to
  - a couple of things the existing `cc_toolchain_config` rule did lack `unix_cc_toolchain_config.bzl:cc_toolchain_config` counterparts:
    + the [make vars](https://github.com/grailbio/bazel-toolchain/blob/f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a/toolchain/cc_toolchain_config.bzl.tpl#L527-L537)
    + the [framework paths feature](https://github.com/grailbio/bazel-toolchain/blob/f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a/toolchain/cc_toolchain_config.bzl.tpl#L347-L365) ([only used on macOS](https://github.com/grailbio/bazel-toolchain/blob/f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a/toolchain/cc_toolchain_config.bzl.tpl#L498-L499))
  - I changed the tool paths to use `llvm-strip` for llvm versions ≥7 ([here](https://github.com/rrbutani/bazel-toolchain/blob/dde617e5cc48d683c086c9da414a0d3ac8d3cd25/toolchain/cc_toolchain_config.bzl.tpl#L183-L188))
  - I'm not confident that I didn't break compatibility with older versions of Bazel
    + I had to gate one of the args to `cc_toolchain_config` on the Bazel version ([here](https://github.com/rrbutani/bazel-toolchain/blob/dde617e5cc48d683c086c9da414a0d3ac8d3cd25/toolchain/cc_toolchain_config.bzl.tpl#L242-L249)) because it was added in v4.0.0
    + looking at the [history](https://github.com/bazelbuild/bazel/blame/da345f1f249ebf28bec88c6e0d63260dfaef14e9/tools/cpp/unix_cc_toolchain_config.bzl#L1248-L1271) for the [attribute list of the `cc_toolchain_config` rule](https://github.com/bazelbuild/bazel/blob/da345f1f249ebf28bec88c6e0d63260dfaef14e9/tools/cpp/unix_cc_toolchain_config.bzl#L1248-L1269) that _seems_ like that's the only change since pre-1.0
     + but I've only tested these changes on Linux with Bazel 3.7.2 and 4.0.0

---

For anyone following along at home, you should be able to try out these changes with:
```starlark
http_archive(
    name = "com_grail_bazel_toolchain",
    strip_prefix = "bazel-toolchain-feature-use-unix-cc-toolchain-config",
    urls = ["https://github.com/rrbutani/bazel-toolchain/archive/feature/use-unix-cc-toolchain-config.tar.gz"],
)
```

---

Closes #23.