### PR TITLE
Support clang-12

### DIFF
--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -160,7 +160,7 @@ def _impl(ctx):
             "-ldl",
             # Other linker flags.
             "-Wl,--build-id=md5",
-            "-Wl,--hash-style=gnu",
+            "-Wl,--hash-style=both",
             "-Wl,-z,relro,-z,now",
         ]
     elif ctx.attr.cpu == "darwin":

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -543,6 +543,7 @@ def _impl(ctx):
     cxx_builtin_include_directories = [
         "%{toolchain_path_prefix}include/c++/v1",
         "%{toolchain_path_prefix}lib/clang/%{llvm_version}/include",
+        "%{toolchain_path_prefix}/lib/clang/%{llvm_version}/share",
         "%{toolchain_path_prefix}lib64/clang/%{llvm_version}/include",
     ]
     if (ctx.attr.cpu == "k8"):

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -109,6 +109,9 @@ def llvm_register_toolchains():
     if not _download_llvm(rctx):
         _download_llvm_preconfigured(rctx)
 
+    rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
+    rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
+
 def conditional_cc_toolchain(name, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.
 

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -120,6 +120,18 @@ _llvm_distributions = {
     "clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "829f5fb0ebda1d8716464394f97d5475d465ddc7bea2879c0601316b611ff6db",
     "clang+llvm-11.0.0-amd64-pc-solaris2.11.tar.xz": "031699337d703fe42843a8326f94079fd67e46b60f25be5bdf47664e158e0b43",
     "clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz": "b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a",
+
+    # 12.0.0
+    "clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz": "697d432c2572e48fc04118fc7cec63c9477ef2e8a7cca2c0b32e52f9705ab1cc",
+    "clang+llvm-12.0.0-i386-unknown-freebsd11.tar.xz": "8298a026f74165bf6088c1c942c22bd7532b12cd2b916f7673bdaf522abe41b0",
+    "clang+llvm-12.0.0-x86_64-apple-darwin.tar.xz": "7bc2259bf75c003f644882460fc8e844ddb23b27236fe43a2787870a4cd8ab50",
+    "clang+llvm-12.0.0-amd64-unknown-freebsd11.tar.xz": "8ff2ae0863d4cbe88ace6cbcce64a1a6c9a8f1237f635125a5d580b2639bba61",
+    "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
+    "clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz": "d05f0b04fb248ce1e7a61fcd2087e6be8bc4b06b2cc348792f383abf414dec48",
+    "clang+llvm-12.0.0-amd64-unknown-freebsd12.tar.xz": "0a90d2cf8a3d71d7d4a6bee3e085405ebc37a854311bce82d6845d93b19fcc87",
+    "clang+llvm-12.0.0-x86_64-linux-sles12.4.tar.xz": "00c25261e303080c2e8d55413a73c60913cdb39cfd47587d6817a86fe52565e9",
+    "clang+llvm-12.0.0-i386-unknown-freebsd12.tar.xz": "1e61921735fd11754df193826306f0352c99ca6013e22f40a7fc77f0b20162be",
+    "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "a9ff205eb0b73ca7c86afc6432eed1c2d49133bd0d49e47b15be59bbf0dd292e",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -135,6 +147,7 @@ _llvm_distributions_base_url = {
     "10.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "10.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "11.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "12.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
 }
 
 def _python(rctx):

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -156,8 +156,8 @@ def download_llvm_preconfigured(rctx):
     llvm_version = rctx.attr.llvm_version
 
     mirror_base = []
-    if rctx.attr.llvm_mirror:
-        mirror_base += [rctx.attr.llvm_mirror]
+    if rctx.attr.llvm_mirror_prefixes:
+        mirror_base += rctx.attr.llvm_mirror_prefixes
 
     if rctx.attr.distribution == "auto":
         exec_result = rctx.execute([
@@ -181,7 +181,7 @@ def download_llvm_preconfigured(rctx):
         "{0}{1}".format(_llvm_distributions_base_url[llvm_version], url_suffix),
     ]
     urls += [
-        "{0}/{1}".format(base, url_suffix)
+        "{0}{1}".format(base, url_suffix)
         for base in mirror_base
     ]
 

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -48,7 +48,7 @@ llvm_toolchain = repository_rule(
                    "directories, keyed by the CPU type (e.g. k8 or darwin). See documentation " +
                    "for bazel's create_cc_toolchain_config_info."),
         ),
-        "llvm_mirror": attr.string(
+        "llvm_mirror_prefixes": attr.string_list(
             doc = "Mirror base for LLVM binaries if using the pre-configured URLs.",
         ),
         "absolute_paths": attr.bool(

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -87,7 +87,10 @@ def _linux(llvm_version):
             os_name = "linux-gnu-ubuntu-20.04"
             
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
-        os_name = "linux-gnu-ubuntu-18.04"
+        if major_llvm_version >= 12:
+            os_name = "linux-gnu-ubuntu-16.04"
+        else:
+            os_name = "linux-gnu-ubuntu-18.04"
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
         # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
         os_name = "linux-gnu-ubuntu-18.04"


### PR DESCRIPTION
Add the archives for clang-12, and add a special rule to say that ubuntu-18.04 should use the ubuntu-16.04 clang build.