### PR TITLE
Put amzn as a known distro but treat it like sles 12.4

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -71,12 +71,6 @@ def _linux(llvm_version):
     # If you find this mapping wrong, please send a Pull Request on Github.
     if arch in ["aarch64", "armv7a", "mips", "mipsel"]:
         os_name = "linux-gnu"
-    # amzn linux was defaulting to sles11.3 because of a typo, this is likely the closest distro based on the ID_LIKE field
-    elif distname == "amzn":
-        if major_llvm_version >= 11:
-            os_name = "linux-sles12.4"
-        else:
-            os_name = "linux-sles11.3"
     elif distname == "freebsd":
         os_name = "unknown-freebsd-%s" % version
     elif distname == "suse":
@@ -91,7 +85,6 @@ def _linux(llvm_version):
         else:
             # release 11.0.0 started providing packaging for ubuntu 20
             os_name = "linux-gnu-ubuntu-20.04"
-            
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         os_name = "linux-gnu-ubuntu-18.04"
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
@@ -118,6 +111,13 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname == "arch" and major_llvm_version >= 7:
         os_name = "linux-gnu-ubuntu-16.04"
+    elif distname == "amzn":
+        # Based on the ID_LIKE field, sles seems like the closest available
+        # distro for which LLVM releases are widely available.
+        if major_llvm_version >= 11:
+            os_name = "linux-sles12.4"
+        else:
+            os_name = "linux-sles11.3"
     else:
         sys.exit("Unsupported linux distribution and version: %s, %s" % (distname, version))
 

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -17,7 +17,7 @@
 import platform
 import sys
 
-_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos"]
+_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn"]
 
 def _major_llvm_version(llvm_version):
     return int(llvm_version.split(".")[0])

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -108,8 +108,6 @@ def _linux(llvm_version):
         os_name = "linux-sles11.3"
     elif distname == "fedora" and major_llvm_version >= 7:
         os_name = "linux-gnu-ubuntu-18.04"
-    elif distname == "amzn" and major_llvm_version >= 7:
-        os_name = "linux-gnu-ubuntu-18.04"
     elif distname == "arch" and major_llvm_version >= 11:
         os_name = "linux-gnu-ubuntu-20.04"
     elif distname == "arch" and major_llvm_version >= 10:

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -72,7 +72,7 @@ def _linux(llvm_version):
     if arch in ["aarch64", "armv7a", "mips", "mipsel"]:
         os_name = "linux-gnu"
     # amzn linux was defaulting to sles11.3 because of a typo, this is likely the closest distro
-    elif distname == "amzn":
+    elif distname == "amzn" and major_llvm_version >= 11:
         os_name = "linux-sles12.4"
     elif distname == "freebsd":
         os_name = "unknown-freebsd-%s" % version

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -71,9 +71,12 @@ def _linux(llvm_version):
     # If you find this mapping wrong, please send a Pull Request on Github.
     if arch in ["aarch64", "armv7a", "mips", "mipsel"]:
         os_name = "linux-gnu"
-    # amzn linux was defaulting to sles11.3 because of a typo, this is likely the closest distro
-    elif distname == "amzn" and major_llvm_version >= 11:
-        os_name = "linux-sles12.4"
+    # amzn linux was defaulting to sles11.3 because of a typo, this is likely the closest distro based on the ID_LIKE field
+    elif distname == "amzn":
+        if major_llvm_version >= 11:
+            os_name = "linux-sles12.4"
+        else:
+            os_name = "linux-sles11.3"
     elif distname == "freebsd":
         os_name = "unknown-freebsd-%s" % version
     elif distname == "suse":

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -71,7 +71,8 @@ def _linux(llvm_version):
     # If you find this mapping wrong, please send a Pull Request on Github.
     if arch in ["aarch64", "armv7a", "mips", "mipsel"]:
         os_name = "linux-gnu"
-    elif distname = "amzn":
+    # amzn linux was defaulting to sles11.3 because of a typo, this is likely the closest distro
+    elif distname == "amzn":
         os_name = "linux-sles12.4"
     elif distname == "freebsd":
         os_name = "unknown-freebsd-%s" % version

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -71,6 +71,8 @@ def _linux(llvm_version):
     # If you find this mapping wrong, please send a Pull Request on Github.
     if arch in ["aarch64", "armv7a", "mips", "mipsel"]:
         os_name = "linux-gnu"
+    elif distname = "amzn":
+        os_name = "linux-sles12.4"
     elif distname == "freebsd":
         os_name = "unknown-freebsd-%s" % version
     elif distname == "suse":


### PR DESCRIPTION
AMZN was never added  to the `_known_distros` list however it was added to the switch statement in https://github.com/grailbio/bazel-toolchain/pull/48