### PR TITLE
Adding Debian 11 as a supported OS

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -92,7 +92,7 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname in ["ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
-    elif distname == "debian" and (version is None or int(version) == 10):
+    elif distname == "debian" and (version is None or int(version) == 10 or int(version) == 11):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname == "debian" and int(version) == 9 and major_llvm_version >= 7:
         os_name = "linux-gnu-ubuntu-16.04"


### PR DESCRIPTION
I added Debian 11 as a supported OS as mentioned in this issue: https://github.com/grailbio/bazel-toolchain/issues/87

No significant changes that I have been able to find have been made to Debian 11 that would prevent this library from working the same as Debian 10.