### PR TITLE
Remove urls attribute of llvm_toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-LLVM toolchain for Bazel ![Tests](https://github.com/grailbio/bazel-toolchain/workflows/Tests/badge.svg?branch=master) ![Migration](https://github.com/grailbio/bazel-toolchain/workflows/Migration/badge.svg?branch=master)
+LLVM toolchain for Bazel [![Tests](https://github.com/grailbio/bazel-toolchain/actions/workflows/tests.yml/badge.svg)](https://github.com/grailbio/bazel-toolchain/actions/workflows/tests.yml) [![Migration](https://github.com/grailbio/bazel-toolchain/actions/workflows/migration.yml/badge.svg)](https://github.com/grailbio/bazel-toolchain/actions/workflows/migration.yml)
 =================
-
-NOTE: As of 2200d53, this project requires bazel 1.0 or up.
 
 To use this toolchain, include this section in your WORKSPACE:
 ```python
@@ -28,7 +26,7 @@ load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
 llvm_register_toolchains()
 ```
 
-The toolchain can automatically detect your OS type, and use the right
+The toolchain can automatically detect your OS and arch type, and use the right
 pre-built binary distribution from llvm.org. The detection is currently
 based on host OS and is not perfect, so some distributions, docker based
 sandboxed builds, and remote execution builds will need toolchains configured
@@ -44,17 +42,20 @@ https://github.com/bazelbuild/bazel/blob/master/site/docs/tutorial/cc-toolchain-
 
 For overriding toolchains on the command line, please use the
 `--extra_toolchains` flag in lieu of the deprecated `--crosstool_top` flag.
-For example, `--extra_toolchains=@llvm_toolchain//:cc-toolchain-linux`.
+For example, `--extra_toolchains=@llvm_toolchain//:cc-toolchain-linux`. You
+may need to also set the `--incompatible_enable_cc_toolchain_resolution` flag.
 
 If you would like to use the older method of selecting toolchains, you can
 continue to do so with `--crosstool_top=@llvm_toolchain//:toolchain`.
 
 Notes:
 
-- The LLVM toolchain archive is downloaded and extracted in the named
-  repository.  People elsewhere have used wrapper scripts to avoid symlinking
-  and get better control of the environment in which the toolchain binaries are
-  run.
+- The LLVM toolchain archive is downloaded and extracted as a separate
+  repository with the suffix `_llvm`. Alternatively, you can also specify your
+  own repositories for each host os-arch pair through the `toolchain_roots`
+  attributes. Each of these repositories is typically configured through
+  `local_repository` or `http_archive` (with `build_file` attribute as
+  `@com_grail_bazel_toolchain//toolchain:BUILD.llvm_repo`).
 
 - A sysroot can be specified through the `sysroot` attribute. This can be either
   a path on the user's system, or a bazel `filegroup` like label. One way to

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -234,21 +234,3 @@ def download_llvm_preconfigured(rctx):
         stripPrefix = basename[:(len(basename) - len(".tar.xz"))],
         auth = _get_auth(rctx, urls),
     )
-
-# Download LLVM from the user-provided URLs and return True. If URLs were not provided, return
-# False.
-def download_llvm(rctx, key):
-    urls = rctx.attr.urls.get(key, default = [])
-    sha256 = rctx.attr.sha256.get(key, default = "")
-    prefix = rctx.attr.strip_prefix.get(key, default = "")
-
-    if not urls:
-        return False
-
-    rctx.download_and_extract(
-        urls,
-        sha256 = sha256,
-        stripPrefix = prefix,
-        auth = _get_auth(rctx, urls),
-    )
-    return True

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -14,25 +14,18 @@
 
 load(
     "//toolchain/internal:common.bzl",
-    _arch = "arch",
-    _check_os_arch_keys = "check_os_arch_keys",
     _os = "os",
-    _os_arch_pair = "os_arch_pair",
 )
 load(
     "//toolchain/internal:llvm_distributions.bzl",
-    _download_llvm = "download_llvm",
     _download_llvm_preconfigured = "download_llvm_preconfigured",
 )
 
 def llvm_repo_impl(rctx):
-    _check_os_arch_keys(rctx.attr.urls)
-
     os = _os(rctx)
     if os == "windows":
         rctx.file("BUILD", executable = False)
         return
-    arch = _arch(rctx)
 
     rctx.file(
         "BUILD.bazel",
@@ -40,6 +33,4 @@ def llvm_repo_impl(rctx):
         executable = False,
     )
 
-    # TODO: Replace download_llvm with standard http_archive rules.
-    if not _download_llvm(rctx, _os_arch_pair(os, arch)):
-        _download_llvm_preconfigured(rctx)
+    _download_llvm_preconfigured(rctx)

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -44,27 +44,6 @@ _llvm_repo_attrs.update({
     "llvm_mirror": attr.string(
         doc = "Mirror base for LLVM binaries if using the pre-configured URLs.",
     ),
-    "_llvm_release_name": attr.label(
-        default = "//toolchain/tools:llvm_release_name.py",
-        allow_single_file = True,
-        doc = "Python module to output LLVM release name for the current OS.",
-    ),
-    # Following attributes are needed only when using a non-standard URL scheme.
-    # TODO: Use standard http_archive here instead of our custom rule.
-    "urls": attr.string_list_dict(
-        mandatory = False,
-        doc = ("URLs for each host OS and arch pair you want to support " +
-               "({}), ".format(", ".join(_supported_os_arch)) +
-               "if not using the pre-configured URLs."),
-    ),
-    "sha256": attr.string_dict(
-        mandatory = False,
-        doc = "sha256 of the archive for each of the above URLs",
-    ),
-    "strip_prefix": attr.string_dict(
-        mandatory = False,
-        doc = "Path prefix to strip from the extracted files.",
-    ),
     "netrc": attr.string(
         mandatory = False,
         doc = "Path to the netrc file for authenticated LLVM URL downloads.",
@@ -72,6 +51,11 @@ _llvm_repo_attrs.update({
     "auth_patterns": attr.string_dict(
         mandatory = False,
         doc = "An optional dict mapping host names to custom authorization patterns.",
+    ),
+    "_llvm_release_name": attr.label(
+        default = "//toolchain/tools:llvm_release_name.py",
+        allow_single_file = True,
+        doc = "Python module to output LLVM release name for the current OS.",
     ),
 })
 


### PR DESCRIPTION
It is now easier to directly use `http_archive` through
`toolchain_roots`.