### PR TITLE
Enable supports_params_file on macOS

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -212,7 +212,6 @@ filegroup(
 """.format(sysroot_label = sysroot_label, toolchain_root = toolchain_root)
 
 def _cc_toolchain_str(name, toolchain_config, darwin, use_absolute_paths):
-    supports_param_files = 0 if darwin else 1
     extra_files = ", \":llvm\", \":cc_wrapper\""
 
     if use_absolute_paths:
@@ -227,7 +226,6 @@ cc_toolchain(
     linker_files = ":empty",
     objcopy_files = ":empty",
     strip_files = ":empty",
-    supports_param_files = {supports_param_files},
     toolchain_config = "{toolchain_config}",
 )
 """
@@ -251,14 +249,12 @@ cc_toolchain(
     linker_files = "{name}-linker-files",
     objcopy_files = ":objcopy",
     strip_files = ":empty",
-    supports_param_files = {supports_param_files},
     toolchain_config = "{toolchain_config}",
 )
 """
 
     return template.format(
         name = name,
-        supports_param_files = supports_param_files,
         toolchain_config = toolchain_config,
         extra_files = extra_files,
     )

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -33,19 +33,32 @@ LIBS=
 LIB_DIRS=
 RPATHS=
 OUTPUT=
-# let parse the option list
-for i in "$@"; do
+
+function parse_option() {
+    local -r opt="$1"
     if [[ "${OUTPUT}" = "1" ]]; then
-        OUTPUT=$i
-    elif [[ "$i" =~ ^-l(.*)$ ]]; then
+        OUTPUT=$opt
+    elif [[ "$opt" =~ ^-l(.*)$ ]]; then
         LIBS="${BASH_REMATCH[1]} $LIBS"
-    elif [[ "$i" =~ ^-L(.*)$ ]]; then
+    elif [[ "$opt" =~ ^-L(.*)$ ]]; then
         LIB_DIRS="${BASH_REMATCH[1]} $LIB_DIRS"
-    elif [[ "$i" =~ ^-Wl,-rpath,\@loader_path/(.*)$ ]]; then
+    elif [[ "$opt" =~ ^-Wl,-rpath,\@loader_path/(.*)$ ]]; then
         RPATHS="${BASH_REMATCH[1]} ${RPATHS}"
-    elif [[ "$i" = "-o" ]]; then
+    elif [[ "$opt" = "-o" ]]; then
         # output is coming
         OUTPUT=1
+    fi
+}
+
+# let parse the option list
+for i in "$@"; do
+    if [[ "$i" = @* ]]; then
+        while IFS= read -r opt
+        do
+            parse_option "$opt"
+        done < "${i:1}" || exit 1
+    else
+        parse_option "$i"
     fi
 done
 
@@ -114,4 +127,3 @@ for rpath in ${RPATHS}; do
         fi
     done
 done
-


### PR DESCRIPTION
Looks like this was supported in bazel from
https://cs.opensource.google/bazel/bazel/+/f08819b731f8bb5d95c196c2781e54908b846b74.