### PR TITLE
Add a test for darwin to linux cross-compilation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: test
-      env:
-        BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
       run: tests/scripts/${{ matrix.script }}
   container_test:
     runs-on: ubuntu-latest
@@ -32,6 +30,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: test
-      env:
-        BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
       run: tests/scripts/${{ matrix.script }}_test.sh
+  xcompile_test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: test
+      run: tests/scripts/run_xcompile_tests.sh

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -1,0 +1,37 @@
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+platform(
+    name = "linux-x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "linux-aarch64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+platform(
+    name = "darwin-x86_64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -20,9 +20,12 @@ cc_library(
     hdrs = ["stdlib.h"],
 )
 
+# We want to emulate the behavior of cc_binary but be able to run the target as
+# a test, so we use a cc_test target with linkstatic.
 cc_test(
     name = "stdlib_test",
     srcs = ["stdlib_test.cc"],
+    linkstatic = True,
     deps = [":stdlib"],
 )
 

--- a/tests/scripts/run_xcompile_tests.sh
+++ b/tests/scripts/run_xcompile_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/bazel.sh"
+"${bazel}" version
+
+binpath="$("${bazel}" info bazel-bin)/tests/stdlib_test"
+
+check_with_image() {
+  if "${CI:-false}"; then
+    # macOS GitHub Action Runners do not have docker installed on them.
+    return
+  fi
+  local image="$1"
+  docker run --rm --mount "type=bind,source=${binpath},target=/stdlib_test" "${image}" /stdlib_test
+}
+
+echo ""
+echo "Testing static linked user libraries and dynamic linked system libraries"
+build_args=(
+  --incompatible_enable_cc_toolchain_resolution
+  --platforms=//platforms:linux-x86_64
+  --extra_toolchains=@llvm_toolchain_with_sysroot//:cc-toolchain-x86_64-linux
+  --symlink_prefix=/
+  --color=yes
+  --show_progress_rate_limit=30
+)
+"${bazel}" --bazelrc=/dev/null build "${build_args[@]}" //tests:stdlib_test
+file "${binpath}" | tee /dev/stderr | grep -q ELF
+check_with_image "frolvlad/alpine-glibc" # Need glibc image for system libraries.
+
+echo ""
+echo "Testing static linked user and system libraries"
+build_args+=(
+  --features=fully_static_link
+)
+"${bazel}" --bazelrc=/dev/null build "${build_args[@]}" //tests:stdlib_test
+file "${binpath}" | tee /dev/stderr | grep -q ELF
+check_with_image "alpine"


### PR DESCRIPTION
Two changes were needed to make cross-compilation actually work:
1. The target triple needed to be provided.
2. C++ standard flags needed to be revised.

The test checks both linkstatic and fully_static modes.

Fixes #20.