### PR TITLE
Fix to release version logic for ubuntu 18.04 and re-enable CI for 18.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         # This list is missing suse_tumbleweed because their latest image is
         # not working, and they don't have versioned images.
         # TODO: Re-enable suse_tumbleweed when their docker image starts working.
-        script: [archlinux, debian, fedora, suse_leap, ubuntu_16_04, ubuntu_20_04, linux_sysroot]
+        script: [archlinux, debian, fedora, suse_leap, ubuntu_16_04, ubuntu_18_04, ubuntu_20_04, linux_sysroot]
     steps:
     - uses: actions/checkout@v2
     - name: test

--- a/tests/scripts/ubuntu_18_04_test.sh
+++ b/tests/scripts/ubuntu_18_04_test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2020 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+images=(
+"ubuntu:18.04"
+)
+
+git_root=$(git rev-parse --show-toplevel)
+readonly git_root
+
+for image in "${images[@]}"; do
+  docker pull "${image}"
+  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+set -exuo pipefail
+
+# Common setup
+export DEBIAN_FRONTEND=noninteractive
+apt-get -qq update
+apt-get -qq -y install apt-utils curl pkg-config zip g++ zlib1g-dev unzip python >/dev/null
+# The above command gives some verbose output that can not be silenced easily.
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
+
+# Run tests
+cd /src
+tests/scripts/run_tests.sh
+"""
+done


### PR DESCRIPTION
I've split out the logic for ubuntu into it's own function.
Also fixes version identification for powerpc64le ubuntu

Closes #101 