### PR TITLE
Moving lpthread and ldl from link_flags to link_libs

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -30,10 +30,9 @@ cc_test(
 )
 
 cc_test(
-    name = "stdlib_dyn_test",
-    srcs = ["stdlib_test.cc"],
+    name = "pthread_link_test",
+    srcs = ["pthread_link_test.cc"],
     linkstatic = False,
-    deps = [":stdlib"],
 )
 
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -29,6 +29,14 @@ cc_test(
     deps = [":stdlib"],
 )
 
+cc_test(
+    name = "stdlib_dyn_test",
+    srcs = ["stdlib_test.cc"],
+    linkstatic = False,
+    deps = [":stdlib"],
+)
+
+
 sh_test(
     name = "file_dependency_test",
     srcs = ["file_dependency_test.sh"],

--- a/tests/pthread_link_test.cc
+++ b/tests/pthread_link_test.cc
@@ -1,0 +1,38 @@
+// Copyright 2021 The Bazel Authors.
+//
+// Licensed under the Apache License, Version 2.0(the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http:  // www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__linux__) && defined(_GNU_SOURCE)
+#include <dlfcn.h>
+#include <assert.h>
+
+// Checks that pthread symbols are loadable.
+//
+// This test verifies that dynamically linked libraries which
+// rely on pthread symbols can still access them.
+// Incorrect order of linking dependencies may remove unused
+// symbols and break shared libraries that are linked later.
+int main() {
+   // Find symbol
+   void* symbol = dlsym(RTLD_NEXT, "pthread_getspecific");
+   // Check that there is no error
+   assert(dlerror() == nullptr && symbol != nullptr);
+
+}
+
+#else//defined(__linux__) && defined(_GNU_SOURCE)
+
+int main() {
+}
+
+#endif//defined(__linux__) && defined(_GNU_SOURCE)

--- a/tests/stdlib.cc
+++ b/tests/stdlib.cc
@@ -15,26 +15,3 @@
 #include <iostream>
 
 void hello() { std::cout << "Hello World!" << std::endl; }
-
-#if defined(__linux__) && defined(_GNU_SOURCE)
-#include <dlfcn.h>
-#include <assert.h>
-
-// Checks that pthread symbols are loadable.
-//
-// This test verifies that dynamically linked libraries which
-// rely on pthread symbols can still access them.
-// Incorrect order of linking dependencies may remove unused
-// symbols and break shared libraries that are linked later.
-void test_pthread_symbols() {
-   // Find symbol
-   void* symbol = dlsym(RTLD_NEXT, "pthread_getspecific");
-   // Check that there is no error
-   assert(dlerror() == nullptr && symbol != nullptr);
-}
-
-#else//defined(__linux__) && defined(_GNU_SOURCE)
-
-void test_pthread_symbols() { }
-
-#endif//defined(__linux__) && defined(_GNU_SOURCE)

--- a/tests/stdlib.cc
+++ b/tests/stdlib.cc
@@ -15,3 +15,26 @@
 #include <iostream>
 
 void hello() { std::cout << "Hello World!" << std::endl; }
+
+#if defined(__linux__) && defined(_GNU_SOURCE)
+#include <dlfcn.h>
+#include <assert.h>
+
+// Checks that pthread symbols are loadable.
+//
+// This test verifies that dynamically linked libraries which
+// rely on pthread symbols can still access them.
+// Incorrect order of linking dependencies may remove unused
+// symbols and break shared libraries that are linked later.
+void test_pthread_symbols() {
+   // Find symbol
+   void* symbol = dlsym(RTLD_NEXT, "pthread_getspecific");
+   // Check that there is no error
+   assert(dlerror() == nullptr && symbol != nullptr);
+}
+
+#else//defined(__linux__) && defined(_GNU_SOURCE)
+
+void test_pthread_symbols() { }
+
+#endif//defined(__linux__) && defined(_GNU_SOURCE)

--- a/tests/stdlib.h
+++ b/tests/stdlib.h
@@ -13,3 +13,5 @@
 // limitations under the License.
 
 void hello();
+
+void test_pthread_symbols();

--- a/tests/stdlib_test.cc
+++ b/tests/stdlib_test.cc
@@ -14,4 +14,7 @@
 
 #include "stdlib.h"
 
-int main() { hello(); }
+int main() {
+    hello();
+    test_pthread_symbols();
+}

--- a/tests/stdlib_test.cc
+++ b/tests/stdlib_test.cc
@@ -16,5 +16,4 @@
 
 int main() {
     hello();
-    test_pthread_symbols();
 }

--- a/tests/stdlib_test.cc
+++ b/tests/stdlib_test.cc
@@ -14,6 +14,4 @@
 
 #include "stdlib.h"
 
-int main() {
-    hello();
-}
+int main() { hello(); }

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -126,6 +126,11 @@ def cc_toolchain_config(
         "-lm",
         "-no-canonical-prefixes",
     ]
+    link_libs = [
+        # To support libunwind.
+        "-lpthread",
+        "-ldl",
+    ]
 
     # Linker flags:
     # Keep this logic in sync with _makevars_ld_flags.
@@ -167,9 +172,6 @@ def cc_toolchain_config(
                 "-l:libunwind.a",
                 # Compiler runtime features.
                 "-rtlib=compiler-rt",
-                # To support libunwind.
-                "-lpthread",
-                "-ldl",
             ])
         else:
             # TODO: Not sure how to achieve static linking of bundled libraries
@@ -274,7 +276,7 @@ def cc_toolchain_config(
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
         link_flags = link_flags,
-        # link_libs = _,
+        link_libs = link_libs,
         opt_link_flags = opt_link_flags,
         unfiltered_compile_flags = unfiltered_compile_flags,
         coverage_compile_flags = coverage_compile_flags,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -126,11 +126,7 @@ def cc_toolchain_config(
         "-lm",
         "-no-canonical-prefixes",
     ]
-    link_libs = [
-        # To support libunwind.
-        "-lpthread",
-        "-ldl",
-    ]
+    link_libs = []
 
     # Linker flags:
     # Keep this logic in sync with _makevars_ld_flags.
@@ -172,6 +168,11 @@ def cc_toolchain_config(
                 "-l:libunwind.a",
                 # Compiler runtime features.
                 "-rtlib=compiler-rt",
+            ])
+            link_libs.extend([
+                # To support libunwind.
+                "-lpthread",
+                "-ldl",
             ])
         else:
             # TODO: Not sure how to achieve static linking of bundled libraries


### PR DESCRIPTION
Putting lpthread into link_flags takes it to the front of link command,
causing linker to remove unused symbols.
This change moves -lpthread and -ldl from link_flags to link_libs which
correctly puts them at the tail.