### PR TITLE
Add missing closing parenthesis on cc_toolchain

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -278,6 +278,7 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     toolchain_config = "local-{suffix}",
+)
 """
     else:
         template = template + """


### PR DESCRIPTION
Closing parenthesis was missing on cc_toolchain definition when
`absolute_paths` is True.