### PR TITLE
Make platforms targets publicly visible

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+package(default_visibility = ["//visibility:public"])
+
 platform(
     name = "linux-x86_64",
     constraint_values = [


### PR DESCRIPTION
Make targets in the platforms package publicly visible so they could be used in the attributes of other targets. 
Example:
```
with_platform(
    name = "linux",
    platform = "@com_grail_bazel_toolchain//platforms:linux-x86_64",
    tool = ":binary",
    visibility = ["//visibility:public"],
)
```