### PR TITLE
Include the symlinked dwp/objcopy/strip files in the toolchain

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
@@ -29,12 +30,27 @@ cc_test(
     deps = [":stdlib"],
 )
 
+# We want to test a `.stripped` target to make sure `llvm-strip` can be called.
+#
+# For this we need `cc_binary`; `cc_test` does not create `.stripped` targets.
+cc_binary(
+    name = "stdlib_bin",
+    srcs = ["stdlib_test.cc"],
+    deps = [":stdlib"],
+)
+
+build_test(
+    name = "stripped_binary_test",
+    targets = [
+        ":stdlib_bin.stripped",
+    ]
+)
+
 cc_test(
     name = "pthread_link_test",
     srcs = ["pthread_link_test.cc"],
     linkstatic = False,
 )
-
 
 sh_test(
     name = "file_dependency_test",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load(":transitions.bzl", "dwp_file")
 
 cc_library(
     name = "stdlib",
@@ -44,6 +45,32 @@ build_test(
     targets = [
         ":stdlib_bin.stripped",
     ]
+)
+
+# We want to test that `llvm-dwp` (used when assembling a `.dwp` file from
+# `.dwo` files) can be called.
+#
+# `--fission=yes` enables this for all compilation modes but we also need to
+# enable the `per_object_debug_info` feature manually because
+# `unix_cc_toolchain_config.bzl`'s` `cc_toolchain_config` does not (see #109).
+#
+# This is what `dwp_file` does using a transition.
+#
+# Unfortunately `per_object_debug_info` breaks on macOS which is why this
+# target is marked as only being compatible with Linux (see #109).
+dwp_file(
+    name = "stdlib.dwp",
+    src = ":stdlib_bin",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+)
+
+build_test(
+    name = "dwp_test",
+    targets = [
+        ":stdlib.dwp",
+    ],
 )
 
 cc_test(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -54,13 +54,34 @@ build_test(
 # enable the `per_object_debug_info` feature manually because
 # `unix_cc_toolchain_config.bzl`'s` `cc_toolchain_config` does not (see #109).
 #
-# This is what `dwp_file` does using a transition.
+# Additionally, newer versions of clang (12+) require a non-zero `-g` setting to
+# actually produce the `.dwo` files in addition to the `-gsplit-dwarf` flag. The
+# feature in `unix_cc_toolchain_config.bzl` should be updated to reflect this
+# and pass in an appropriate `-g` flag.
 #
-# Unfortunately `per_object_debug_info` breaks on macOS which is why this
-# target is marked as only being compatible with Linux (see #109).
+# bazelbuild/rules_cc#115 is a patch that does this
+# (https://github.com/bazelbuild/rules_cc/pull/115).
+#
+# bazelbuild/bazel#14028 tracks this
+# (https://github.com/bazelbuild/bazel/issues/14038).
+#
+# #109 in this repo and this comment
+# (https://github.com/grailbio/bazel-toolchain/pull/108#issuecomment-928839768)
+# have some additional details.
+#
+# For now, we'll specify `-c dbg` when building `.dwo` and `.dwp` files.
+#
+# This (setting the fission flag, enabling the `per_object_debug_info` feature,
+# and setting the compilation mode to `dbg`) is what `dwp_file` does using a
+# transition.
+#
+# Unfortunately `per_object_debug_info` breaks on macOS which is why this target
+# is marked as only being compatible with Linux (see #109).
 dwp_file(
     name = "stdlib.dwp",
     src = ":stdlib_bin",
+    # NOTE: we should eventually we able to drop this; see #109.
+    override_compilation_mode = "dbg",
     target_compatible_with = [
         "@platforms//os:linux",
     ],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test", "cc_binary")
 load(":transitions.bzl", "dwp_file")
 
 cc_library(

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -1,0 +1,58 @@
+"""Helper transitions for tests."""
+
+def _fission_transition_impl(settings, attr):
+    features = settings["//command_line_option:features"]
+    if "per_object_debug_info" in features:
+        features.remove("per_object_debug_info")
+
+    enable_per_object_debug_info = attr.per_object_debug_info
+    if enable_per_object_debug_info:
+        features.append("per_object_debug_info")
+
+    return {
+        "//command_line_option:fission": attr.fission,
+        "//command_line_option:features": features,
+    }
+
+fission_transition = transition(
+    implementation = _fission_transition_impl,
+    inputs = ["//command_line_option:features"],
+    outputs = [
+        "//command_line_option:features",
+        "//command_line_option:fission",
+    ],
+)
+
+def _dwp_file_impl(ctx):
+    file = ctx.attr.name
+    file = ctx.actions.declare_file(file)
+    ctx.actions.symlink(
+        output = file,
+        target_file = ctx.attr.src[0][DebugPackageInfo].dwp_file,
+    )
+
+    return [DefaultInfo(files = depset([file]))]
+
+dwp_file = rule(
+    implementation = _dwp_file_impl,
+    attrs = {
+        "src": attr.label(
+            cfg = fission_transition,
+            mandatory = True,
+            doc = "The actual target to build and grab the .dwp file from.",
+            providers = [DebugPackageInfo],
+        ),
+        # NOTE: we should eventually be able to remove this (see #109).
+        "per_object_debug_info": attr.bool(
+            default = True,
+        ),
+        "fission": attr.string(
+            default = "yes",
+            values = ["yes", "no", "dbg", "fastbuild", "opt"],
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist"
+        ),
+    },
+    incompatible_use_toolchain_transition = True,
+)

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -1,5 +1,10 @@
 """Helper transitions for tests."""
 
+# This transition function sets `--features=per_object_debug_info` and
+# `--fission` as well as the compilation mode.
+#
+# These three Bazel flags influence whether or not `.dwo` and `.dwp` are
+# created.
 def _fission_transition_impl(settings, attr):
     features = settings["//command_line_option:features"]
     if "per_object_debug_info" in features:
@@ -9,15 +14,24 @@ def _fission_transition_impl(settings, attr):
     if enable_per_object_debug_info:
         features.append("per_object_debug_info")
 
+    compilation_mode = settings["//command_line_option:compilation_mode"]
+    if attr.override_compilation_mode:
+        compilation_mode = attr.override_compilation_mode
+
     return {
+        "//command_line_option:compilation_mode": compilation_mode,
         "//command_line_option:fission": attr.fission,
         "//command_line_option:features": features,
     }
 
 fission_transition = transition(
     implementation = _fission_transition_impl,
-    inputs = ["//command_line_option:features"],
+    inputs = [
+        "//command_line_option:compilation_mode",
+        "//command_line_option:features",
+    ],
     outputs = [
+        "//command_line_option:compilation_mode",
         "//command_line_option:features",
         "//command_line_option:fission",
     ],
@@ -49,6 +63,19 @@ dwp_file = rule(
         "fission": attr.string(
             default = "yes",
             values = ["yes", "no", "dbg", "fastbuild", "opt"],
+        ),
+        # NOTE: this should eventually not be necessary; see #109 for context
+        # and also:
+        #   - https://reviews.llvm.org/D80391
+        #   - https://github.com/bazelbuild/bazel/issues/14038
+        #   - https://github.com/bazelbuild/rules_cc/pull/115
+        #
+        # Essentially, we now need to specify `-g2` explicitly to generate
+        # `.dwo` files.
+        "override_compilation_mode": attr.string(
+            default = "",
+            mandatory = False,
+            values = ["dbg", "fastbuild", "opt"],
         ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist"

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -119,3 +119,8 @@ filegroup(
     name = "readelf",
     srcs = ["bin/llvm-readelf"],
 )
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/llvm-strip"],
+)

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -320,7 +320,9 @@ filegroup(name = "all-files-{suffix}", srcs = [":all-components-{suffix}"{extra_
 filegroup(name = "archiver-files-{suffix}", srcs = ["{toolchain_root}:ar"{extra_files_str}])
 filegroup(name = "assembler-files-{suffix}", srcs = ["{toolchain_root}:as"{extra_files_str}])
 filegroup(name = "compiler-files-{suffix}", srcs = [":compiler-components-{suffix}"{extra_files_str}])
+filegroup(name = "dwp-files-{suffix}", srcs = ["{toolchain_root}:dwp"{extra_files_str}])
 filegroup(name = "linker-files-{suffix}", srcs = [":linker-components-{suffix}"{extra_files_str}])
+filegroup(name = "objcopy-files-{suffix}", srcs = ["{toolchain_root}:objcopy"{extra_files_str}])
 
 cc_toolchain(
     name = "cc-clang-{suffix}",
@@ -328,9 +330,9 @@ cc_toolchain(
     ar_files = "archiver-files-{suffix}",
     as_files = "assembler-files-{suffix}",
     compiler_files = "compiler-files-{suffix}",
-    dwp_files = "{toolchain_root}:dwp",
+    dwp_files = "dwp-files-{suffix}",
     linker_files = "linker-files-{suffix}",
-    objcopy_files = "{toolchain_root}:objcopy",
+    objcopy_files = "objcopy-files-{suffix}",
     strip_files = ":empty",
     toolchain_config = "local-{suffix}",
 )

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -323,6 +323,7 @@ filegroup(name = "compiler-files-{suffix}", srcs = [":compiler-components-{suffi
 filegroup(name = "dwp-files-{suffix}", srcs = ["{toolchain_root}:dwp"{extra_files_str}])
 filegroup(name = "linker-files-{suffix}", srcs = [":linker-components-{suffix}"{extra_files_str}])
 filegroup(name = "objcopy-files-{suffix}", srcs = ["{toolchain_root}:objcopy"{extra_files_str}])
+filegroup(name = "strip-files-{suffix}", srcs = ["{toolchain_root}:strip"{extra_files_str}])
 
 cc_toolchain(
     name = "cc-clang-{suffix}",
@@ -333,7 +334,7 @@ cc_toolchain(
     dwp_files = "dwp-files-{suffix}",
     linker_files = "linker-files-{suffix}",
     objcopy_files = "objcopy-files-{suffix}",
-    strip_files = ":empty",
+    strip_files = "strip-files-{suffix}",
     toolchain_config = "local-{suffix}",
 )
 """


### PR DESCRIPTION
Without the `:llvm` target the toolchain files are missing when using sandbox.