### PR TITLE
Allow selection of stdlib to use

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,7 +51,9 @@ filegroup(
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
     llvm_version = "12.0.0",
-    stdlib = "stdc++",
+    stdlib = {
+        "linux-x86_64": "stdc++",
+    },
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
     },

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,7 @@ filegroup(
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
     llvm_version = "12.0.0",
+    stdlib = "stdc++",
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
     },

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -99,6 +99,7 @@ def llvm_register_toolchains():
     toolchain_info = struct(
         os = os,
         arch = arch,
+        stdlib = rctx.attr.stdlib,
         toolchain_root = toolchain_root,
         toolchain_path_prefix = toolchain_path_prefix,
         tools_path_prefix = tools_path_prefix,
@@ -142,8 +143,8 @@ def llvm_register_toolchains():
         "BUILD.bazel",
         Label("//toolchain:BUILD.toolchain.tpl"),
         {
-            "%{cc_toolchains}": cc_toolchains_str,
             "%{cc_toolchain_config_bzl}": str(rctx.attr._cc_toolchain_config_bzl),
+            "%{cc_toolchains}": cc_toolchains_str,
         },
     )
 
@@ -217,6 +218,7 @@ def _cc_toolchain_str(
         host_tools_info):
     host_os = toolchain_info.os
     host_arch = toolchain_info.arch
+    stdlib = toolchain_info.stdlib
 
     host_os_bzl = _os_bzl(host_os)
     target_os_bzl = _os_bzl(target_os)
@@ -263,6 +265,7 @@ cc_toolchain_config(
     tools_path_prefix = "{tools_path_prefix}",
     wrapper_bin_prefix = "{wrapper_bin_prefix}",
     sysroot_path = "{sysroot_path}",
+    stdlib = "{stdlib}",
     additional_include_dirs = {additional_include_dirs_str},
     llvm_version = "{llvm_version}",
     host_tools_info = {host_tools_info},
@@ -361,6 +364,7 @@ cc_toolchain(
         target_arch = target_arch,
         host_os = host_os,
         host_arch = host_arch,
+        stdlib = stdlib,
         target_os_bzl = target_os_bzl,
         host_os_bzl = host_os_bzl,
         toolchain_root = toolchain_info.toolchain_root,

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -99,11 +99,11 @@ def llvm_register_toolchains():
     toolchain_info = struct(
         os = os,
         arch = arch,
-        stdlib = rctx.attr.stdlib,
         toolchain_root = toolchain_root,
         toolchain_path_prefix = toolchain_path_prefix,
         tools_path_prefix = tools_path_prefix,
         wrapper_bin_prefix = wrapper_bin_prefix,
+        stdlib_dict = rctx.attr.stdlib,
         additional_include_dirs_dict = rctx.attr.cxx_builtin_include_directories,
         sysroot_dict = rctx.attr.sysroot,
         default_sysroot_path = default_sysroot_path,
@@ -218,7 +218,6 @@ def _cc_toolchain_str(
         host_tools_info):
     host_os = toolchain_info.os
     host_arch = toolchain_info.arch
-    stdlib = toolchain_info.stdlib
 
     host_os_bzl = _os_bzl(host_os)
     target_os_bzl = _os_bzl(target_os)
@@ -238,6 +237,8 @@ def _cc_toolchain_str(
             return ""
 
     extra_files_str = ", \":llvm\", \":wrapper-files\""
+
+    stdlib = toolchain_info.stdlib_dict.get(_os_arch_pair(target_os, target_arch), "builtin-libc++")
 
     additional_include_dirs = toolchain_info.additional_include_dirs_dict.get(_os_arch_pair(target_os, target_arch))
     additional_include_dirs_str = "[]"

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -34,6 +34,22 @@ _common_attrs = {
 
 _llvm_repo_attrs = dict(_common_attrs)
 _llvm_repo_attrs.update({
+    "alternative_llvm_sources": attr.string_list(
+        doc = "Patterns for alternative LLVM release sources. Unlike URLs specified for `llvm_mirror` " +
+              "these do not have to follow the same structure as the official LLVM release sources." +
+              "\n\n" +
+              "Patterns may include `{llvm_version}` (which will be substituted for the full LLVM " +
+              "version, i.e. 13.0.0) and `{basename}` (which will be replaced with the filename " +
+              "used by the official LLVM release sources for a particular distribution; i.e. " +
+              "`llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz`)." +
+              "\n\n" +
+              "As with `llvm_mirror`, these sources will take precedence over the official LLVM " +
+              "release sources.",
+    ),
+    "auth_patterns": attr.string_dict(
+        mandatory = False,
+        doc = "An optional dict mapping host names to custom authorization patterns.",
+    ),
     "distribution": attr.string(
         default = "auto",
         doc = ("LLVM pre-built binary distribution filename, must be one " +
@@ -52,25 +68,9 @@ _llvm_repo_attrs.update({
               "sources (see: " +
               "https://github.com/grailbio/bazel-toolchain/toolchain/internal/llvm_distributions.bzl).",
     ),
-    "alternative_llvm_sources": attr.string_list(
-        doc = "Patterns for alternative LLVM release sources. Unlike URLs specified for `llvm_mirror` " +
-              "these do not have to follow the same structure as the official LLVM release sources." +
-              "\n\n" +
-              "Patterns may include `{llvm_version}` (which will be substituted for the full LLVM " +
-              "version, i.e. 13.0.0) and `{basename}` (which will be replaced with the filename " +
-              "used by the official LLVM release sources for a particular distribution; i.e. " +
-              "`llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz`)." +
-              "\n\n" +
-              "As with `llvm_mirror`, these sources will take precedence over the official LLVM " +
-              "release sources.",
-    ),
     "netrc": attr.string(
         mandatory = False,
         doc = "Path to the netrc file for authenticated LLVM URL downloads.",
-    ),
-    "auth_patterns": attr.string_dict(
-        mandatory = False,
-        doc = "An optional dict mapping host names to custom authorization patterns.",
     ),
     "_llvm_release_name": attr.label(
         default = "//toolchain/tools:llvm_release_name.py",
@@ -81,6 +81,32 @@ _llvm_repo_attrs.update({
 
 _llvm_config_attrs = dict(_common_attrs)
 _llvm_config_attrs.update({
+    "absolute_paths": attr.bool(
+        default = False,
+        doc = "Use absolute paths in the toolchain. Avoids sandbox overhead.",
+    ),
+    "cxx_builtin_include_directories": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Additional builtin include directories to be added to the default system " +
+               "directories, for each target OS and arch pair you want to support " +
+               "({}); ".format(", ".join(_supported_os_arch_keys())) +
+               "see documentation for bazel's create_cc_toolchain_config_info."),
+    ),
+    "stdlib": attr.string(
+        default = "builtin-libc++",
+        doc = "Which stdlib implementation should be used. Default is `builtin-libc++` which uses the libc++ shipped with clang. Use `none` to pass `-nostdlib` to the compiler",
+        values = ["builtin-libc++", "stdc++", "none"],
+    ),
+    "sysroot": attr.string_dict(
+        mandatory = False,
+        doc = ("System path or fileset, for each target OS and arch pair you want to support " +
+               "({}), ".format(", ".join(_supported_os_arch_keys())) +
+               "used to indicate the set of files that form the sysroot for the compiler. " +
+               "If the value begins with exactly one forward slash '/', then the value is " +
+               "assumed to be a system path. Else, the value will be assumed to be a label " +
+               "containing the files and the sysroot path will be taken as the path to the " +
+               "package of this label."),
+    ),
     "toolchain_roots": attr.string_dict(
         mandatory = True,
         # TODO: Ideally, we should be taking a filegroup label here instead of a package path, but
@@ -94,27 +120,6 @@ _llvm_config_attrs.update({
                "assumed to be a system path and the toolchain is configured to use absolute " +
                "paths. Else, the value will be assumed to be a bazel package containing the " +
                "filegroup targets as in BUILD.llvm_repo."),
-    ),
-    "sysroot": attr.string_dict(
-        mandatory = False,
-        doc = ("System path or fileset, for each target OS and arch pair you want to support " +
-               "({}), ".format(", ".join(_supported_os_arch_keys())) +
-               "used to indicate the set of files that form the sysroot for the compiler. " +
-               "If the value begins with exactly one forward slash '/', then the value is " +
-               "assumed to be a system path. Else, the value will be assumed to be a label " +
-               "containing the files and the sysroot path will be taken as the path to the " +
-               "package of this label."),
-    ),
-    "cxx_builtin_include_directories": attr.string_list_dict(
-        mandatory = False,
-        doc = ("Additional builtin include directories to be added to the default system " +
-               "directories, for each target OS and arch pair you want to support " +
-               "({}); ".format(", ".join(_supported_os_arch_keys())) +
-               "see documentation for bazel's create_cc_toolchain_config_info."),
-    ),
-    "absolute_paths": attr.bool(
-        default = False,
-        doc = "Use absolute paths in the toolchain. Avoids sandbox overhead.",
     ),
     "_cc_toolchain_config_bzl": attr.label(
         default = "//toolchain:cc_toolchain_config.bzl",

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -34,22 +34,6 @@ _common_attrs = {
 
 _llvm_repo_attrs = dict(_common_attrs)
 _llvm_repo_attrs.update({
-    "alternative_llvm_sources": attr.string_list(
-        doc = "Patterns for alternative LLVM release sources. Unlike URLs specified for `llvm_mirror` " +
-              "these do not have to follow the same structure as the official LLVM release sources." +
-              "\n\n" +
-              "Patterns may include `{llvm_version}` (which will be substituted for the full LLVM " +
-              "version, i.e. 13.0.0) and `{basename}` (which will be replaced with the filename " +
-              "used by the official LLVM release sources for a particular distribution; i.e. " +
-              "`llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz`)." +
-              "\n\n" +
-              "As with `llvm_mirror`, these sources will take precedence over the official LLVM " +
-              "release sources.",
-    ),
-    "auth_patterns": attr.string_dict(
-        mandatory = False,
-        doc = "An optional dict mapping host names to custom authorization patterns.",
-    ),
     "distribution": attr.string(
         default = "auto",
         doc = ("LLVM pre-built binary distribution filename, must be one " +
@@ -68,9 +52,25 @@ _llvm_repo_attrs.update({
               "sources (see: " +
               "https://github.com/grailbio/bazel-toolchain/toolchain/internal/llvm_distributions.bzl).",
     ),
+    "alternative_llvm_sources": attr.string_list(
+        doc = "Patterns for alternative LLVM release sources. Unlike URLs specified for `llvm_mirror` " +
+              "these do not have to follow the same structure as the official LLVM release sources." +
+              "\n\n" +
+              "Patterns may include `{llvm_version}` (which will be substituted for the full LLVM " +
+              "version, i.e. 13.0.0) and `{basename}` (which will be replaced with the filename " +
+              "used by the official LLVM release sources for a particular distribution; i.e. " +
+              "`llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz`)." +
+              "\n\n" +
+              "As with `llvm_mirror`, these sources will take precedence over the official LLVM " +
+              "release sources.",
+    ),
     "netrc": attr.string(
         mandatory = False,
         doc = "Path to the netrc file for authenticated LLVM URL downloads.",
+    ),
+    "auth_patterns": attr.string_dict(
+        mandatory = False,
+        doc = "An optional dict mapping host names to custom authorization patterns.",
     ),
     "_llvm_release_name": attr.label(
         default = "//toolchain/tools:llvm_release_name.py",
@@ -81,32 +81,6 @@ _llvm_repo_attrs.update({
 
 _llvm_config_attrs = dict(_common_attrs)
 _llvm_config_attrs.update({
-    "absolute_paths": attr.bool(
-        default = False,
-        doc = "Use absolute paths in the toolchain. Avoids sandbox overhead.",
-    ),
-    "cxx_builtin_include_directories": attr.string_list_dict(
-        mandatory = False,
-        doc = ("Additional builtin include directories to be added to the default system " +
-               "directories, for each target OS and arch pair you want to support " +
-               "({}); ".format(", ".join(_supported_os_arch_keys())) +
-               "see documentation for bazel's create_cc_toolchain_config_info."),
-    ),
-    "stdlib": attr.string(
-        default = "builtin-libc++",
-        doc = "Which stdlib implementation should be used. Default is `builtin-libc++` which uses the libc++ shipped with clang. Use `none` to pass `-nostdlib` to the compiler",
-        values = ["builtin-libc++", "stdc++", "none"],
-    ),
-    "sysroot": attr.string_dict(
-        mandatory = False,
-        doc = ("System path or fileset, for each target OS and arch pair you want to support " +
-               "({}), ".format(", ".join(_supported_os_arch_keys())) +
-               "used to indicate the set of files that form the sysroot for the compiler. " +
-               "If the value begins with exactly one forward slash '/', then the value is " +
-               "assumed to be a system path. Else, the value will be assumed to be a label " +
-               "containing the files and the sysroot path will be taken as the path to the " +
-               "package of this label."),
-    ),
     "toolchain_roots": attr.string_dict(
         mandatory = True,
         # TODO: Ideally, we should be taking a filegroup label here instead of a package path, but
@@ -120,6 +94,36 @@ _llvm_config_attrs.update({
                "assumed to be a system path and the toolchain is configured to use absolute " +
                "paths. Else, the value will be assumed to be a bazel package containing the " +
                "filegroup targets as in BUILD.llvm_repo."),
+    ),
+    "sysroot": attr.string_dict(
+        mandatory = False,
+        doc = ("System path or fileset, for each target OS and arch pair you want to support " +
+               "({}), ".format(", ".join(_supported_os_arch_keys())) +
+               "used to indicate the set of files that form the sysroot for the compiler. " +
+               "If the value begins with exactly one forward slash '/', then the value is " +
+               "assumed to be a system path. Else, the value will be assumed to be a label " +
+               "containing the files and the sysroot path will be taken as the path to the " +
+               "package of this label."),
+    ),
+    "stdlib": attr.string_dict(
+        mandatory = False,
+        doc = "stdlib implementation, for each target OS and arch pair you want to support " +
+              "({}), ".format(", ".join(_supported_os_arch_keys())) +
+              "linked to the compiled binaries. Possible values are `builtin-libc++` (default) " +
+              "which uses the libc++ shipped with clang, `libc++` which uses libc++ available on " +
+              "the host or sysroot, `libstdc++` which uses libstdc++ available on the host or " +
+              "sysroot, and `none` which uses `-nostdlib` with the compiler.",
+    ),
+    "cxx_builtin_include_directories": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Additional builtin include directories to be added to the default system " +
+               "directories, for each target OS and arch pair you want to support " +
+               "({}); ".format(", ".join(_supported_os_arch_keys())) +
+               "see documentation for bazel's create_cc_toolchain_config_info."),
+    ),
+    "absolute_paths": attr.bool(
+        default = False,
+        doc = "Use absolute paths in the toolchain. Avoids sandbox overhead.",
     ),
     "_cc_toolchain_config_bzl": attr.label(
         default = "//toolchain:cc_toolchain_config.bzl",


### PR DESCRIPTION
Adds a `use_libcpp` attribute to the `llvm_toolchain` repository rule to allow selection of whether `libc++` or `stdc++` is used.