### PR TITLE
platforms: fix the constraints for `//platforms:linux-aarch64`

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -25,7 +25,7 @@ platform(
 platform(
     name = "linux-aarch64",
     constraint_values = [
-        "@platforms//os:osx",
+        "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
 )


### PR DESCRIPTION
Fixes #117.