### PR TITLE
Always use ubuntu16.04 binaries for arch linux

### DIFF
--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -34,7 +34,7 @@ Server = https://repo.archlinuxcn.org/\$arch
 EOF
 
 # Install dependencies
-pacman -Syu --noconfirm --quiet python ncurses5-compat-libs
+pacman -Syu --noconfirm --quiet archlinuxcn-keyring python ncurses5-compat-libs
 
 # Run tests
 cd /src

--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -34,7 +34,8 @@ Server = https://repo.archlinuxcn.org/\$arch
 EOF
 
 # Install dependencies
-pacman -Syu --noconfirm --quiet archlinuxcn-keyring python ncurses5-compat-libs
+pacman -Syu --noconfirm --quiet archlinuxcn-keyring
+pacman -S --noconfirm --quiet python ncurses5-compat-libs
 
 # Run tests
 cd /src

--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -27,8 +27,14 @@ for image in "${images[@]}"; do
   docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
+# add archlinuxcn repo for ncurses5-compat-libs (can be installed from AUR, but this is easier & faster)
+cat >> /etc/pacman.conf <<'EOF'
+[archlinuxcn]
+Server = https://repo.archlinuxcn.org/$arch
+EOF
+
 # Install dependencies
-pacman -Syu --noconfirm --quiet python
+pacman -Syu --noconfirm --quiet python ncurses5-compat-libs
 
 # Run tests
 cd /src

--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -30,7 +30,7 @@ set -exuo pipefail
 # add archlinuxcn repo for ncurses5-compat-libs (can be installed from AUR, but this is easier & faster)
 cat >> /etc/pacman.conf <<'EOF'
 [archlinuxcn]
-Server = https://repo.archlinuxcn.org/$arch
+Server = https://repo.archlinuxcn.org/\$arch
 EOF
 
 # Install dependencies

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -140,11 +140,7 @@ def _linux(llvm_version, arch):
             os_name = "linux-gnu-ubuntu-18.04"
         else:
             os_name = "linux-gnu-ubuntu-20.04"
-    elif distname == "arch" and major_llvm_version >= 11:
-        os_name = "linux-gnu-ubuntu-20.04"
-    elif distname == "arch" and major_llvm_version >= 10:
-        os_name = "linux-gnu-ubuntu-18.04"
-    elif distname == "arch" and major_llvm_version >= 7:
+    elif distname == "arch":
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "amzn":
         # Based on the ID_LIKE field, sles seems like the closest available


### PR DESCRIPTION
Using ubuntu20.04 binaries on arch linux has an unfortunate side-effect of printing `external/llvm_toolchain_llvm/bin/clang: /usr/lib/libtinfo.so.6: no version information available (required by external/llvm_toolchain_llvm/bin/clang)` for each invocation of clang. While these warnings do not pose any danger except being an annoyance, there is no reasonably simple way to suppress them (see https://refi64.com/posts/qldv.html). Binaries for ubuntu16.04 do not have this problem though and seem to work fine, although requiring an `ncurses5-compat-libs` package

I am not sure if this change is appropriate for the master, as it requires additional dependencies to be installed. Lower versions of LLVM would require this package too, though