### PR TITLE
Allows customized c++ standard.

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -38,6 +38,7 @@ def cc_toolchain_config(
         sysroot_path,
         additional_include_dirs,
         llvm_version,
+        cxx_standard,
         host_tools_info = {}):
     host_os_arch_key = _os_arch_pair(host_os, host_arch)
     target_os_arch_key = _os_arch_pair(target_os, target_arch)
@@ -157,7 +158,7 @@ def cc_toolchain_config(
     # always link C++ libraries.
     if not is_xcompile:
         cxx_flags = [
-            "-std=c++17",
+            "-std=" + cxx_standard,
             "-stdlib=libc++",
         ]
         if use_lld:
@@ -185,7 +186,7 @@ def cc_toolchain_config(
             ])
     else:
         cxx_flags = [
-            "-std=c++17",
+            "-std=" + cxx_standard,
             "-stdlib=libstdc++",
         ]
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -194,7 +194,7 @@ def cc_toolchain_config(
             ])
     elif stdlib == "libc++":
         cxx_flags = [
-            "-std=c++17",
+            "-std=" + cxx_standard,
             "-stdlib=libc++",
         ]
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -107,6 +107,7 @@ def llvm_register_toolchains():
         sysroot_dict = rctx.attr.sysroot,
         default_sysroot_path = default_sysroot_path,
         llvm_version = rctx.attr.llvm_version,
+        cxx_standard = rctx.attr.cxx_standard,
     )
     host_tools_info = dict([
         pair
@@ -265,6 +266,7 @@ cc_toolchain_config(
     sysroot_path = "{sysroot_path}",
     additional_include_dirs = {additional_include_dirs_str},
     llvm_version = "{llvm_version}",
+    cxx_standard = "{cxx_standard}",
     host_tools_info = {host_tools_info},
 )
 
@@ -373,4 +375,5 @@ cc_toolchain(
         llvm_version = toolchain_info.llvm_version,
         extra_files_str = extra_files_str,
         host_tools_info = host_tools_info,
+        cxx_standard = toolchain_info.cxx_standard,
     )

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -105,6 +105,11 @@ _llvm_config_attrs.update({
                "containing the files and the sysroot path will be taken as the path to the " +
                "package of this label."),
     ),
+    "cxx_standard": attr.string(
+        mandatory = False,
+        doc = "C++ standard, passed as `-std` flag to compiler.",
+        default = "c++17",
+    ),
     "cxx_builtin_include_directories": attr.string_list_dict(
         mandatory = False,
         doc = ("Additional builtin include directories to be added to the default system " +


### PR DESCRIPTION
Allows user specify c++ standard using `cxx_standard` attribute of `llvm_toolchain` rule, instead of hardcoded "c++17".