### PR TITLE
Bazel: Added support for openmp

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -31,6 +31,13 @@ cc_test(
     deps = [":stdlib"],
 )
 
+cc_test(
+    name = "omp_test",
+    srcs = ["omp_test.c"],
+    copts = ["-fopenmp"],
+    linkopts = ["-fopenmp"],
+)
+
 # We want to test a `.stripped` target to make sure `llvm-strip` can be called.
 #
 # For this we need `cc_binary`; `cc_test` does not create `.stripped` targets.

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -36,6 +36,7 @@ cc_test(
     srcs = ["omp_test.c"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
+    deps = ["@llvm_toolchain//:omp"],
 )
 
 # We want to test a `.stripped` target to make sure `llvm-strip` can be called.

--- a/tests/omp_test.c
+++ b/tests/omp_test.c
@@ -1,0 +1,11 @@
+// OpenMP header
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+// Beginning of parallel region
+#pragma omp parallel
+  { printf("Hello World... from thread = %d\n", omp_get_thread_num()); }
+  // Ending of parallel region
+}

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -56,6 +56,7 @@ filegroup(
     srcs = glob(
         [
             "lib/lib*.a",
+            "lib/lib*.so",
             "lib/clang/*/lib/**/*.a",
         ],
         exclude = [

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -56,7 +56,6 @@ filegroup(
     srcs = glob(
         [
             "lib/lib*.a",
-            "lib/lib*.so",
             "lib/clang/*/lib/**/*.a",
         ],
         exclude = [

--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -33,4 +33,9 @@ filegroup(
     ],
 )
 
+cc_import(
+    name = "omp",
+    shared_library = "%{llvm_repo_label_prefix}lib/libomp.%{host_dl_ext}",
+)
+
 %{cc_toolchains}


### PR DESCRIPTION
Otherwise, bazel build //tests:omp_test will fail:

```
ld.lld: error: unable to find library -lomp
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Target //tests:hello_omp failed to build
```

However, it still requires "libomp.so" can be found in ldconfig path during runtime.