### PR TITLE
User overrides for all flags

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -84,6 +84,11 @@ def pkg_path_from_label(label):
     else:
         return label.package
 
+def list_to_string(l):
+    if l == None:
+        return "None"
+    return "[{}]".format(", ".join(["\"{}\"".format(d) for d in l]))
+
 def attr_dict(attr):
     # Returns a mutable dict of attr values from the struct. This is useful to
     # return updated attribute values as return values of repository_rule

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -102,7 +102,129 @@ _llvm_repo_attrs.update({
     ),
 })
 
+_target_pairs = ", ".join(_supported_os_arch_keys())
+
+_compiler_configuration_attrs = {
+    "sysroot": attr.string_dict(
+        mandatory = False,
+        doc = ("System path or fileset, for each target OS and arch pair you want to support " +
+               "({}), ".format(_target_pairs) +
+               "used to indicate the set of files that form the sysroot for the compiler. " +
+               "If the value begins with exactly one forward slash '/', then the value is " +
+               "assumed to be a system path. Else, the value will be assumed to be a label " +
+               "containing the files and the sysroot path will be taken as the path to the " +
+               "package of this label."),
+    ),
+    "cxx_builtin_include_directories": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Additional builtin include directories to be added to the default system " +
+               "directories, for each target OS and arch pair you want to support " +
+               "({}); ".format(_target_pairs) +
+               "see documentation for bazel's create_cc_toolchain_config_info."),
+    ),
+    "stdlib": attr.string_dict(
+        mandatory = False,
+        doc = ("stdlib implementation, for each target OS and arch pair you want to support " +
+               "({}), ".format(_target_pairs) +
+               "linked to the compiled binaries. An empty key can be used to specify a " +
+               "value for all target pairs. Possible values are `builtin-libc++` (default) " +
+               "which uses the libc++ shipped with clang, `libc++` which uses libc++ available on " +
+               "the host or sysroot, `libstdc++` which uses libstdc++ available on the host or " +
+               "sysroot, and `none` which uses `-nostdlib` with the compiler."),
+    ),
+    "cxx_standard": attr.string_dict(
+        mandatory = False,
+        doc = ("C++ standard, for each target OS and arch pair you want to support " +
+               "({}), ".format(_target_pairs) +
+               "passed as `-std` flag to the compiler. An empty key can be used to specify a " +
+               "value for all target pairs. Default value is c++17."),
+    ),
+    # For default values of all the below flags overrides, consult
+    # cc_toolchain_config.bzl in this directory.
+    "compile_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for compile_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "cxx_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for cxx_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "link_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for link_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "link_libs": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for link_libs, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "opt_compile_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for opt_compile_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "opt_link_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for opt_link_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "dbg_compile_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for dbg_compile_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "coverage_compile_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for coverage_compile_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "coverage_link_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for coverage_link_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+    "unfiltered_compile_flags": attr.string_list_dict(
+        mandatory = False,
+        doc = ("Override for unfiltered_compile_flags, replacing the default values. " +
+               "`{toolchain_path_prefix}` in the flags will be substituted by the path " +
+               "to the root LLVM distribution directory. Provide one list for each " +
+               "target OS and arch pair you want to override " +
+               "({}); empty key overrides all.".format(_target_pairs)),
+    ),
+}
+
 _llvm_config_attrs = dict(_common_attrs)
+_llvm_config_attrs.update(_compiler_configuration_attrs)
 _llvm_config_attrs.update({
     "toolchain_roots": attr.string_dict(
         mandatory = True,
@@ -110,44 +232,13 @@ _llvm_config_attrs.update({
         # we ultimately need to subset the files to be more selective in what we include in the
         # sandbox for which operations, and it is not straightforward to subset a filegroup.
         doc = ("System or package path, for each host OS and arch pair you want to support " +
-               "({}), ".format(", ".join(_supported_os_arch_keys())) +
-               "to be used as the LLVM toolchain distributions. An empty key can be used to " +
-               "specify a fallback default for all hosts, e.g. with the llvm_toolchain_repo rule. " +
+               "({}), ".format(_target_pairs) + "to be used as the LLVM toolchain " +
+               "distributions. An empty key can be used to specify a fallback default for " +
+               "all hosts, e.g. with the llvm_toolchain_repo rule. " +
                "If the value begins with exactly one forward slash '/', then the value is " +
                "assumed to be a system path and the toolchain is configured to use absolute " +
                "paths. Else, the value will be assumed to be a bazel package containing the " +
                "filegroup targets as in BUILD.llvm_repo."),
-    ),
-    "sysroot": attr.string_dict(
-        mandatory = False,
-        doc = ("System path or fileset, for each target OS and arch pair you want to support " +
-               "({}), ".format(", ".join(_supported_os_arch_keys())) +
-               "used to indicate the set of files that form the sysroot for the compiler. " +
-               "If the value begins with exactly one forward slash '/', then the value is " +
-               "assumed to be a system path. Else, the value will be assumed to be a label " +
-               "containing the files and the sysroot path will be taken as the path to the " +
-               "package of this label."),
-    ),
-    "cxx_standard": attr.string(
-        mandatory = False,
-        doc = "C++ standard, passed as `-std` flag to compiler.",
-        default = "c++17",
-    ),
-    "stdlib": attr.string_dict(
-        mandatory = False,
-        doc = "stdlib implementation, for each target OS and arch pair you want to support " +
-              "({}), ".format(", ".join(_supported_os_arch_keys())) +
-              "linked to the compiled binaries. Possible values are `builtin-libc++` (default) " +
-              "which uses the libc++ shipped with clang, `libc++` which uses libc++ available on " +
-              "the host or sysroot, `libstdc++` which uses libstdc++ available on the host or " +
-              "sysroot, and `none` which uses `-nostdlib` with the compiler.",
-    ),
-    "cxx_builtin_include_directories": attr.string_list_dict(
-        mandatory = False,
-        doc = ("Additional builtin include directories to be added to the default system " +
-               "directories, for each target OS and arch pair you want to support " +
-               "({}); ".format(", ".join(_supported_os_arch_keys())) +
-               "see documentation for bazel's create_cc_toolchain_config_info."),
     ),
     "absolute_paths": attr.bool(
         default = False,


### PR DESCRIPTION
Most users require some configurability of the toolchain through being
able to override the default:
1. stdlib
2. c++ standard
3. linker

The first two have already been solved through attributes to the
repository rule. Instead of continuing to add specialized repository
rules, we should pass through all flag groups in bazel's
unix_cc_toolchain_config.bzl as repository rule attributes. The existing
defaults continue to exist, but users now have the option to override
these defaults for each target os-arch pair.

These flag overrides can also contain a placeholder to the root
directory for the LLVM distribution.

An example solution to satisfy #132 (using mold linker) could be one of:
- Pick up mold linker and libstdc++ from the host.
```
llvm_toolchain(
    name = "llvm_toolchain",
    link_flags = {"": [
        "-lm",
        "-no-canonical-prefixes",
        "-fuse-ld=mold",
        "-Wl,--build-id=md5",
        "-Wl,--hash-style=gnu",
        "-Wl,-z,relro,-z,now",
        "-l:libstdc++.a",
    ]},
    stdlib = {"": "stdc++"},
    llvm_version = "12.0.0",
)
```
- Pick up mold linker from the host but continue to link bundled libc++.
```
llvm_toolchain(
    name = "llvm_toolchain",
    link_flags = {"": [
        "-lm",
        "-no-canonical-prefixes",
        "-fuse-ld=mold",
        "-Wl,--build-id=md5",
        "-Wl,--hash-style=gnu",
        "-Wl,-z,relro,-z,now",
        "-L{toolchain_path_prefix}lib",
        "-l:libc++.a",
        "-l:libc++abi.a",
        "-l:libunwind.a",
        "-rtlib=compiler-rt",
    ]},
    llvm_version = "12.0.0",
)
```