### PR TITLE
chore: glob's allow_empty defaults to True

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -68,7 +68,6 @@ filegroup(
             "lib/lib*.dylib",
             "lib/clang/*/lib/**/*.dylib",
         ],
-        allow_empty = True,
     ),
 )
 


### PR DESCRIPTION
https://docs.bazel.build/versions/5.1.0/be/functions.html#glob