### PR TITLE
Provide llvm-symbolizer target

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -123,3 +123,8 @@ filegroup(
     name = "strip",
     srcs = ["bin/llvm-strip"],
 )
+
+filegroup(
+    name = "symbolizer",
+    srcs = ["bin/llvm-symbolizer"],
+)


### PR DESCRIPTION
AddressSanitizer uses llvm-symbolizer binary to symbolize the stack traces, and the llvm-symbolizer version must match the version of ASan runtime library. https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports

By exposing this target, users can configure the appropriate `ASAN_SYMBOLIZER_PATH` environment variable:

```
cc_test(
  ...
  data = [
    ...,
    "@llvm_toolchain_llvm//:symbolizer",
  ],
  env = {
    "ASAN_SYMBOLIZER_PATH": "$(location @llvm_toolchain_llvm//:symbolizer)",
  },
)
```

(Ideally the toolchain would set this up automatically, but I don't know if there's a way for a toolchain to specify environment variables for `cc_test` that use that toolchain. [I asked on Bazel slack.](https://bazelbuild.slack.com/archives/CGA9QFQ8H/p1659500841502059))