### PR TITLE
Fix documentation for libstdc++ stdlib attribute

### DIFF
--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -129,7 +129,7 @@ _compiler_configuration_attrs = {
                "linked to the compiled binaries. An empty key can be used to specify a " +
                "value for all target pairs. Possible values are `builtin-libc++` (default) " +
                "which uses the libc++ shipped with clang, `libc++` which uses libc++ available on " +
-               "the host or sysroot, `libstdc++` which uses libstdc++ available on the host or " +
+               "the host or sysroot, `stdc++` which uses libstdc++ available on the host or " +
                "sysroot, and `none` which uses `-nostdlib` with the compiler."),
     ),
     "cxx_standard": attr.string_dict(


### PR DESCRIPTION
See https://github.com/grailbio/bazel-toolchain/blob/3cf6c59742b58980093e2062e9ec056c3bd492e5/toolchain/cc_toolchain_config.bzl#L207