### PR TITLE
Add support for RHEL 8 & 9

### DIFF
--- a/toolchain/tools/host_os_key.py
+++ b/toolchain/tools/host_os_key.py
@@ -19,7 +19,8 @@ import platform
 import sys
 
 
-_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn", "raspbian", "pop"]
+_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian",
+                  "fedora", "centos", "amzn", "raspbian", "pop", "rhel"]
 
 
 def _linux_dist():

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -122,6 +122,11 @@ def _linux(llvm_version, distname, version, arch):
     elif distname == "raspbian":
         arch = "armv7a"
         os_name = "linux-gnueabihf"
+    elif distname == "rhel":
+        if 8 <= float(version) < 9:
+            os_name = _ubuntu_osname(arch, "18.04", major_llvm_version, llvm_version)
+        elif float(version) >= 9:
+            os_name = _ubuntu_osname(arch, "20.04", major_llvm_version, llvm_version)
     else:
         sys.exit("Unsupported linux distribution and version: %s, %s" % (distname, version))
 


### PR DESCRIPTION
Adds support for RHEL 8 and 9 by mapping them to ubuntu 18.04 and 20.04 respectively.

This ensures that we download a copy that was built against a compatible version of glibc.

This was tested with the Redhat ubi8 and ubi9 container images targetting llvm-12.0.0. For both, you might need to install `libstdc++-static` and `g++` to get standard headers.

Ubi8 test results
- Results in a lot of INFO level messages `external/llvm_toolchain_llvm/bin/clang: /lib64/libtinfo.so.5: no version information available (required by external/llvm_toolchain_llvm/bin/clang)`

Ubi9 test results
- Results in a lot of INFO level messages `external/llvm_toolchain_llvm/bin/clang: /lib64/libtinfo.so.6: no version information available (required by external/llvm_toolchain_llvm/bin/clang)`