### PR TITLE
--incompatible_disallow_empty_glob fix for bazel 7.0

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -70,6 +70,7 @@ filegroup(
             "lib/lib*.dylib",
             "lib/clang/*/lib/**/*.dylib",
         ],
+        allow_empty = True
     ),
 )
 


### PR DESCRIPTION
Newer versions of bazel change the default behavior of globs.  I'm seeing the following error:
```
Error in glob: glob pattern 'lib/lib*.dylib' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: /home/luxe/.cache/bazel/_bazel_luxe/d2b58f5aeb052ef14f5024fa6a16621f/external/llvm_toolchain/BUILD.bazel:172:6: Target '@llvm_toolchain_llvm//:bin/clang-format' contains an error and its package is in error and referenced by '@llvm_toolchain//:clang-format'
```

The solution may be to remove the `"lib/lib*.dylib"` line, but in this case, I've added he allow_empty flag explicitly.