### PR TITLE
Define aliased tools as binaries

### DIFF
--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -14,6 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 load("%{cc_toolchain_config_bzl}", "cc_toolchain_config")
 

--- a/toolchain/aliases.bzl
+++ b/toolchain/aliases.bzl
@@ -20,6 +20,8 @@ aliased_libs = [
 ]
 
 aliased_tools = [
+    "clang-apply-replacements",
     "clang-format",
+    "clang-tidy",
     "llvm-cov",
 ]

--- a/toolchain/deps.bzl
+++ b/toolchain/deps.bzl
@@ -23,3 +23,17 @@ def bazel_toolchain_dependencies():
             strip_prefix = "rules_cc-726dd8157557f1456b3656e26ab21a1646653405",
             urls = ["https://github.com/bazelbuild/rules_cc/archive/726dd8157557f1456b3656e26ab21a1646653405.tar.gz"],
         )
+
+    # Load bazel_skylib if the user has not defined them.
+    if not native.existing_rule("bazel_skylib"):
+        http_archive(
+            name = "bazel_skylib",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+            ],
+            sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+        )
+
+        # we aren't using lib/unittest.bzl so we can skip
+        # bazel_skylib_workspace

--- a/toolchain/deps.bzl
+++ b/toolchain/deps.bzl
@@ -35,5 +35,4 @@ def bazel_toolchain_dependencies():
             sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
         )
 
-        # we aren't using lib/unittest.bzl so we can skip
-        # bazel_skylib_workspace
+        # Skip bazel_skylib_workspace because we are not using lib/unittest.bzl

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -511,9 +511,10 @@ cc_import(
     tool_target_strs = []
     for name in _aliased_tools:
         template = """
-alias(
+native_binary(
     name = "{name}",
-    actual = "{{llvm_dist_label_prefix}}bin/{name}",
+    out = "{name}",
+    src = "{{llvm_dist_label_prefix}}bin/{name}",
 )""".format(name = name)
         tool_target_strs.append(template)
 


### PR DESCRIPTION
Define tools as sh_binary's instead of aliases to filegroups, allowing use with rules that expect `files_to_run.executable` attributes (e.g. https://github.com/erenon/bazel_clang_tidy).