### PR TITLE
export llvm include files

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -18,6 +18,7 @@ package(default_visibility = ["//visibility:public"])
 exports_files(glob([
     "bin/*",
     "lib/*",
+    "include/*",
 ]))
 
 ## LLVM toolchain files


### PR DESCRIPTION
I'm building [cppast](https://github.com/foonathan/cppast) from source and it relies on `libclang`.  The project references these include files directly so it may make sense to export them as well.