### PR TITLE
Fixes for macOS

### DIFF
--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -27,6 +27,10 @@ bazel_toolchain_dependencies()
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
+# Latest LLVM version is 15.0.6 as of this writing but OS support is rather
+# sparse for all our container tests and some cgo tests crash with LLVM 15.
+# TODO: Consider keeping the container tests to be on 14.0.0 when not supported
+# by 15.0.6.
 LLVM_VERSION = "14.0.0"
 
 llvm_toolchain(

--- a/tests/openssl/openssl.bazel
+++ b/tests/openssl/openssl.bazel
@@ -172,6 +172,7 @@ genrule(
         "perl $(location crypto/x86_64cpuid.pl) $$FLAVOR $(location crypto/x86_64cpuid.s)",
         "perl $(location engines/asm/e_padlock-x86_64.pl) $$FLAVOR $(location engines/e_padlock-x86_64.s)",
     ]),
+    target_compatible_with = ["@platforms//cpu:x86_64"],
 )
 
 cc_library(

--- a/tests/scripts/bazel.sh
+++ b/tests/scripts/bazel.sh
@@ -18,7 +18,7 @@ readonly os
 arch="$(uname -m)"
 if [[ "${arch}" == "x86_64" ]]; then
   arch="amd64"
-elif [[ "${arch}" == "aarch64" ]]; then
+elif [[ "${arch}" == "aarch64" ]] || [[ "${arch}" == "arm64" ]]; then
   arch="arm64"
 else
   >&2 echo "Unknown architecture: ${arch}"

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -25,10 +25,16 @@ cd "${scripts_dir}"
 "${bazel}" fetch @io_bazel_rules_go//tests/core/cgo:all
 "$("${bazel}" info output_base)/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
 
+test_args=(
+  "${common_test_args[@]}"
+  # Options needed for LLVM 15 when we switch to using it for these tests
+  #"--copt=-Wno-deprecated-builtins" # https://github.com/abseil/abseil-cpp/issues/1201
+)
+
 # We exclude the following targets:
 # - cc_libs_test from rules_go because it assumes that stdlibc++ has been dynamically linked, but we
 #   link it statically on linux.
-"${bazel}" --bazelrc=/dev/null test "${common_test_args[@]}" -- \
+"${bazel}" --bazelrc=/dev/null test "${test_args[@]}" -- \
   //foreign:pcre \
   @openssl//:libssl \
   @rules_rust//test/unit/{native_deps,linkstamps,interleaved_cc_info}:all \

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -71,7 +71,7 @@ filegroup(
             "lib/lib*.dylib",
             "lib/clang/*/lib/**/*.dylib",
         ],
-        allow_empty = True
+        allow_empty = True,
     ),
 )
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -156,6 +156,9 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
+            # This will issue a warning on macOS ventura; see:
+            #  https://github.com/python/cpython/issues/97524
+            #  https://developer.apple.com/forums/thread/719961
             "-undefined",
             "dynamic_lookup",
         ])

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -42,6 +42,8 @@ function parse_option() {
         LIBS="${BASH_REMATCH[1]} $LIBS"
     elif [[ "$opt" =~ ^-L(.*)$ ]]; then
         LIB_DIRS="${BASH_REMATCH[1]} $LIB_DIRS"
+    elif [[ "$opt" =~ ^\@loader_path/(.*)$ ]]; then
+        RPATHS="${BASH_REMATCH[1]} ${RPATHS}"
     elif [[ "$opt" =~ ^-Wl,-rpath,\@loader_path/(.*)$ ]]; then
         RPATHS="${BASH_REMATCH[1]} ${RPATHS}"
     elif [[ "$opt" = "-o" ]]; then


### PR DESCRIPTION
With newer versions of macOS, LLVM and Bazel, a few things have changed and need to be accounted.

- Chained fixups is a new feature that generates a warning when dynamic lookup is used for undefined symbols. Bazel's default local toolchain has now removed the dynamic lookups. See https://github.com/bazelbuild/bazel/issues/16413
- Bazel 6.0.0 onwards have started using @loader_path; we need to update the wrapper script to handle these options accordingly.
- Some basic test fixes for macOS M1 when an LLVM distribution is available, e.g. for LLVM version 15.0.0.