### PR TITLE
Update LLVM version in tests to 15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Re-enable suse_leap, suse_tumbleweed; see https://github.com/grailbio/bazel-toolchain/issues/143.
-        script: [archlinux, debian, fedora, ubuntu_18_04, ubuntu_20_04, linux_sysroot]
+        script: [archlinux, debian, fedora, suse_leap, suse_tumbleweed, ubuntu_18_04, ubuntu_20_04, linux_sysroot]
     steps:
     - uses: actions/checkout@v2
     - name: test
@@ -53,10 +52,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Download and Extract LLVM distribution
       env:
-        release: "llvmorg-14.0.0"
-        archive: "clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04"
+        release: "llvmorg-15.0.6"
+        archive: "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04"
         ext: ".tar.xz"
-        local_path: "/tmp/llvm-14"
+        local_path: "/tmp/llvm-15"
       run: wget --no-verbose "https://github.com/llvm/llvm-project/releases/download/${release}/${archive}${ext}" && tar -xf "${archive}${ext}" && mv "${archive}" "${local_path}"
     - name: test
       run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -100,6 +100,10 @@ cc_test(
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
     deps = ["@llvm_toolchain//:omp"],
+    # On macOS, LLVM 15 tries to dynamically link libc++abi from the distribution.
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )
 
 sh_test(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -20,26 +20,46 @@ local_repository(
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
 
 bazel_toolchain_dependencies()
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
-# Latest LLVM version is 15.0.6 as of this writing but OS support is rather
-# sparse for all our container tests and some cgo tests crash with LLVM 15.
-# TODO: Consider keeping the container tests to be on 14.0.0 when not supported
-# by 15.0.6.
-LLVM_VERSION = "14.0.0"
+# When updating this version, also update the versions associated with
+# llvm_toolchain below, sys_paths_test in the worflows file, and xcompile_test
+# through the `llvm_toolchain_with_sysroot` toolchain.
+LLVM_VERSION = "15.0.6"
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    llvm_version = LLVM_VERSION,
-    # To test (manually) if the URLs feature works to fetch an archive.
-    #sha256 = {"": "61582215dafafb7b576ea30cc136be92c877ba1f1c31ddbbd372d6d65622fef5"},
-    #strip_prefix = {"": "clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04"},
-    #urls = {"": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"]},
+    llvm_versions = {
+        "": "15.0.6",
+        "darwin-aarch64": "15.0.7",
+        "darwin-x86_64": "15.0.7",
+    },
+    sha256 = {
+        "": "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036",
+        "darwin-aarch64": "867c6afd41158c132ef05a8f1ddaecf476a26b91c85def8e124414f9a9ba188d",
+        "darwin-x86_64": "d16b6d536364c5bec6583d12dd7e6cf841b9f508c4430d9ee886726bd9983f1c",
+    },
+    strip_prefix = {
+        "": "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04",
+        "darwin-aarch64": "clang+llvm-15.0.7-arm64-apple-darwin22.0",
+        "darwin-x86_64": "clang+llvm-15.0.7-x86_64-apple-darwin21.0",
+    },
+    urls = {
+        "": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz"],
+        "darwin-aarch64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-arm64-apple-darwin22.0.tar.xz"],
+        "darwin-x86_64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz"],
+    },
+)
+
+# This is the latest version of LLVM that seems to work with rules_go; later
+# versions cause the tests to crash.
+llvm_toolchain(
+    name = "llvm_toolchain_14_0_0",
+    llvm_version = "14.0.0",
 )
 
 # This is the last known LLVM version with zlib support in ld.lld. Without zlib
@@ -72,7 +92,7 @@ llvm_toolchain(
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     # A path in /tmp to be part of system tmp cleanup schedule.
-    toolchain_roots = {"": "/tmp/llvm-14"},
+    toolchain_roots = {"": "/tmp/llvm-15"},
 )
 
 ## Toolchain example with a sysroot.
@@ -93,7 +113,11 @@ filegroup(
 
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_version = LLVM_VERSION,
+    llvm_versions = {
+        "": "15.0.6",
+        "darwin-x86_64": "15.0.7",
+        "darwin-aarch64": "15.0.7",
+    },
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
     },
@@ -105,11 +129,11 @@ llvm_toolchain(
 
 http_archive(
     name = "bazel_skylib",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
     ],
-    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -27,6 +27,9 @@ cd "${scripts_dir}"
 
 test_args=(
   "${common_test_args[@]}"
+  # Fix LLVM version to be 14.0.0 because that's the last known version with
+  # which the tests in rules_go pass.
+  "--extra_toolchains=@llvm_toolchain_14_0_0//:all"
   # Options needed for LLVM 15 when we switch to using it for these tests
   #"--copt=-Wno-deprecated-builtins" # https://github.com/abseil/abseil-cpp/issues/1201
 )

--- a/tests/scripts/suse_leap_test.sh
+++ b/tests/scripts/suse_leap_test.sh
@@ -19,6 +19,9 @@ images=(
 "opensuse/leap:latest"
 )
 
+# See note next to the definition of this toolchain in the WORKSPACE file.
+toolchain="@llvm_toolchain_13_0_0//:cc-toolchain-x86_64-linux"
+
 git_root=$(git rev-parse --show-toplevel)
 readonly git_root
 
@@ -35,6 +38,6 @@ zypper -n install curl python tar gzip gcc libc++1 libncurses5 binutils-gold
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh
+tests/scripts/run_tests.sh -t ${toolchain}
 """
 done

--- a/tests/scripts/suse_tumbleweed_test.sh
+++ b/tests/scripts/suse_tumbleweed_test.sh
@@ -19,6 +19,9 @@ images=(
 "opensuse/tumbleweed:latest"
 )
 
+# See note next to the definition of this toolchain in the WORKSPACE file.
+toolchain="@llvm_toolchain_13_0_0//:cc-toolchain-x86_64-linux"
+
 git_root=$(git rev-parse --show-toplevel)
 readonly git_root
 
@@ -35,6 +38,6 @@ zypper -n install pkgconf-pkg-config curl python tar gzip findutils gcc libc++1 
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh
+tests/scripts/run_tests.sh -t ${toolchain}
 """
 done

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -47,6 +47,7 @@ def _include_dirs_str(rctx, key):
 
 def llvm_config_impl(rctx):
     _check_os_arch_keys(rctx.attr.toolchain_roots)
+    _check_os_arch_keys(rctx.attr.llvm_versions)
     _check_os_arch_keys(rctx.attr.sysroot)
     _check_os_arch_keys(rctx.attr.cxx_builtin_include_directories)
 
@@ -66,6 +67,11 @@ def llvm_register_toolchains():
         toolchain_root = rctx.attr.toolchain_roots.get("")
     if not toolchain_root:
         fail("LLVM toolchain root missing for ({}, {})", os, arch)
+    llvm_version = rctx.attr.llvm_versions.get(key)
+    if not llvm_version:
+        llvm_version = rctx.attr.llvm_versions.get("")
+    if not llvm_version:
+        fail("LLVM version string missing for ({}, {})", os, arch)
 
     config_repo_path = "external/%s/" % rctx.name
 
@@ -155,7 +161,7 @@ def llvm_register_toolchains():
         coverage_compile_flags_dict = rctx.attr.coverage_compile_flags,
         coverage_link_flags_dict = rctx.attr.coverage_link_flags,
         unfiltered_compile_flags_dict = rctx.attr.unfiltered_compile_flags,
-        llvm_version = rctx.attr.llvm_version,
+        llvm_version = llvm_version,
     )
     host_dl_ext = "dylib" if os == "darwin" else "so"
     host_tools_info = dict([

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
-load("//toolchain/internal:common.bzl", _attr_dict = "attr_dict", _python = "python")
+load("//toolchain/internal:common.bzl", _arch = "arch", _attr_dict = "attr_dict", _os = "os", _os_arch_pair = "os_arch_pair", _python = "python")
 
 # If a new LLVM version is missing from this list, please add the shasums here
 # and send a PR on github. To compute the shasum block, you can run (for example):
@@ -232,6 +232,12 @@ _llvm_distributions = {
     "clang+llvm-15.0.6-powerpc64le-linux-rhel-8.4.tar.xz": "c26e5563e6ff46a03bc45fe27547c69283b64cba2359ccd3a42f735c995c0511",
     "clang+llvm-15.0.6-powerpc64le-linux-ubuntu-18.04.tar.xz": "7fc9f07ff0fcf191df93fe4adc1da555e43f62fe1d3ddafb15c943f72b1bda17",
     "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036",
+
+    # 15.0.7
+    "clang+llvm-15.0.7-arm64-apple-darwin22.0.tar.xz": "867c6afd41158c132ef05a8f1ddaecf476a26b91c85def8e124414f9a9ba188d",
+    "clang+llvm-15.0.7-powerpc64le-linux-rhel-8.4.tar.xz": "2163cc934437146dc30810a21a46327ba3983f123c3bea19be316a64135b6414",
+    "clang+llvm-15.0.7-powerpc64le-linux-ubuntu-18.04.tar.xz": "19a16d768e15966923b0cbf8fc7dc148c89e316857acd89ad3aff72dcfcd61f4",
+    "clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz": "d16b6d536364c5bec6583d12dd7e6cf841b9f508c4430d9ee886726bd9983f1c",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -303,7 +309,7 @@ def download_llvm(rctx):
     return updated_attrs
 
 def _urls(rctx):
-    key = _host_os_key(rctx)
+    key = _os_arch_pair(_os(rctx), _arch(rctx))
 
     key_orig = key
     if key not in rctx.attr.urls:
@@ -344,17 +350,6 @@ def _distribution_urls(rctx):
     strip_prefix = basename[:(len(basename) - len(".tar.xz"))]
 
     return urls, sha256, strip_prefix
-
-def _host_os_key(rctx):
-    exec_result = rctx.execute([
-        _python(rctx),
-        rctx.path(rctx.attr._os_version_arch),
-    ])
-    if exec_result.return_code:
-        fail("Failed to detect host OS name and version: \n%s\n%s" % (exec_result.stdout, exec_result.stderr))
-    if exec_result.stderr:
-        print(exec_result.stderr)
-    return exec_result.stdout.strip()
 
 def _llvm_release_name(rctx, llvm_version):
     exec_result = rctx.execute([

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -28,17 +28,24 @@ def _minor_llvm_version(llvm_version):
 def _patch_llvm_version(llvm_version):
     return int(llvm_version.split(".")[2])
 
-def _darwin_apple_suffix(major_llvm_version, arch):
+def _darwin_apple_suffix(llvm_version, arch):
+    major_llvm_version = _major_llvm_version(llvm_version)
+    patch_llvm_version = _patch_llvm_version(llvm_version)
     if major_llvm_version == 9:
         "darwin-apple"
-    elif arch == "arm64":
-        return "apple-darwin21.0"
+    elif major_llvm_version >= 15:
+        if arch == "arm64":
+            if patch_llvm_version <= 6:
+                return "apple-darwin21.0"
+            else:
+                return "apple-darwin22.0"
+        else:
+            return "apple-darwin21.0"
     else:
         return "apple-darwin"
 
 def _darwin(llvm_version, arch):
-    major_llvm_version = _major_llvm_version(llvm_version)
-    suffix = _darwin_apple_suffix(major_llvm_version, arch)
+    suffix = _darwin_apple_suffix(llvm_version, arch)
     return "clang+llvm-{llvm_version}-{arch}-{suffix}.tar.xz".format(
         llvm_version=llvm_version, arch=arch, suffix=suffix)
 


### PR DESCRIPTION
External tests still need to be on 14, because of crashes in some tests with LLVM 15.

Suse tests work with LLVM 13 now, so they have been re-enabled (fixes #143).