### PR TITLE
fix arch in darwin release name

### DIFF
--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -29,6 +29,8 @@ def _darwin_apple_suffix(llvm_version, arch):
         return "apple-darwin"
 
 def _darwin(llvm_version, arch):
+    if arch == "aarch64":
+        arch = "arm64"
     suffix = _darwin_apple_suffix(llvm_version, arch)
     return "clang+llvm-{llvm_version}-{arch}-{suffix}.tar.xz".format(
         llvm_version = llvm_version,


### PR DESCRIPTION
Without this using on arm64 macOS fails with:
`Error in fail: Unknown LLVM release: clang+llvm-15.0.6-aarch64-apple-darwin21.0.tar.xz`