### PR TITLE
Add all_includes target for building loadable clang-tidy plugins

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -48,6 +48,11 @@ filegroup(
 )
 
 filegroup(
+  name = "all_includes",
+  srcs = glob(["include/**"]),
+)
+
+filegroup(
     name = "bin",
     srcs = glob(["bin/**"]),
 )


### PR DESCRIPTION
Hello

I would like to add the following filegroup "all_includes".

by exposing all includes it is possible for users of this toolchain to build clang-tidy plugins compatible with the toolchain`s clang-tidy binary, using the `-load=` option of clang-tidy.

thank you for your time.
