### PR TITLE
Remove use of -undefined dynamic_lookup on darwin

### DIFF
--- a/tests/scripts/bazel.sh
+++ b/tests/scripts/bazel.sh
@@ -40,6 +40,10 @@ readonly common_test_args=(
   --test_output=errors
 )
 
+if [[ $(uname -s) == 'Darwin' ]]; then
+  common_test_args+=(--features=-supports_dynamic_linker)
+fi
+
 # Do not run autoconf to configure local CC toolchains.
 export BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 

--- a/tests/scripts/bazel.sh
+++ b/tests/scripts/bazel.sh
@@ -31,7 +31,7 @@ readonly url="https://github.com/bazelbuild/bazelisk/releases/download/${bazelis
 bazel="${TMPDIR:-/tmp}/bazelisk"
 readonly bazel
 
-readonly common_test_args=(
+common_test_args=(
   --incompatible_enable_cc_toolchain_resolution
   --symlink_prefix=/
   --color=yes

--- a/tests/scripts/bazel.sh
+++ b/tests/scripts/bazel.sh
@@ -40,6 +40,8 @@ common_test_args=(
   --test_output=errors
 )
 
+# TODO: Remove this once we no longer support bazel 6.x.
+# This feature isn't intentionally supported on macOS.
 if [[ $(uname -s) == 'Darwin' ]]; then
   common_test_args+=(--features=-supports_dynamic_linker)
 fi

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -156,11 +156,6 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
-            # This will issue a warning on macOS ventura; see:
-            #  https://github.com/python/cpython/issues/97524
-            #  https://developer.apple.com/forums/thread/719961
-            "-undefined",
-            "dynamic_lookup",
         ])
     else:
         # Note that for xcompiling from darwin to linux, the native ld64 is

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -156,6 +156,7 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
+            "-fobjc-link-runtime",
         ])
     else:
         # Note that for xcompiling from darwin to linux, the native ld64 is


### PR DESCRIPTION
This flag ignores undefined symbols at link time and forces them to be
looked up dynamically. This is incompatible with the newer fixup chains
macho format and theoretically shouldn't be necessary assuming your
dependencies are well defined.

Done in bazel's toolchain here https://github.com/bazelbuild/bazel/pull/16414
