### PR TITLE
Allow rule `llvm_toolchain` to use attribute `llvm_versions` to refer to

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ attributes to `llvm_toolchain`.
 
 ## Advanced Usage
 
-#### Per target LLVM version
+#### Per host architecture LLVM version
 
-LLVM does not come with distributions for all targets in each version. In
-particular mini versions often come with few prebuilt packages. This means
-that a single version probably is not enough to address all targets one wants
-to support.
+LLVM does not come with distributions for all host architectures in each
+version. In particular patch versions often come with few prebuilt packages.
+This means that a single version probably is not enough to address all hosts
+one wants to support.
 
 This can be solved by providing a target/version map with a default version.
 The example below selects `15.0.6` as the default version for all targets not
@@ -156,11 +156,12 @@ and instead rely on the `--incompatible_enable_cc_toolchain_resolution` flag.
 The following mechanisms are available for using an LLVM toolchain:
 
 1. Host OS information is used to find the right pre-built binary distribution
-   from llvm.org, given the `llvm_version` attribute. The LLVM toolchain
-   archive is downloaded and extracted as a separate repository with the suffix
-   `_llvm`. The detection is not perfect, so you may have to use other options
-   for some host OS type and versions. We expect the detection logic to grow
-   through community contributions. We welcome PRs.
+   from llvm.org, given the `llvm_version` or `llvm_versions` attribute. The
+   LLVM toolchain archive is downloaded and extracted as a separate repository
+   with the suffix `_llvm`. The detection logic for `llvm_version` is not
+   perfect, so you may have to use `llvm_versions` for some host OS type and
+   versions. We expect the detection logic to grow through community
+   contributions. We welcome PRs.
 2. You can use the `urls` attribute to specify your own URLs for each OS type,
    version and architecture. For example, you can specify a different URL for
    Arch Linux and a different one for Ubuntu. Just as with the option above,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    llvm_version = "15.0.6",
+    llvm_versions = {
+        "": "15.0.6",
+        "darwin-aarch64": "15.0.7",
+        "darwin-x86_64": "15.0.7",
+    },
 )
 
 load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")

--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-aarch64": "15.0.7",
-        "darwin-x86_64": "15.0.7",
-    },
+    llvm_version = "16.0.0",
 )
 
 load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
@@ -73,6 +69,30 @@ See in-code documentation in [rules.bzl](toolchain/rules.bzl) for available
 attributes to `llvm_toolchain`.
 
 ## Advanced Usage
+
+#### Per target LLVM version
+
+LLVM does not come with distributions for all targets in each version. In
+particular mini versions often come with few prebuilt packages. This means
+that a single version probably is not enough to address all targets one wants
+to support.
+
+This can be solved by providing a target/version map with a default version.
+The example below selects `15.0.6` as the default version for all targets not
+specified explicitly. This is like providing `llvm_version = "15.0.6"`, just
+like in the example on the top. However, here we provide two more entries that
+map their respective target to a distinct version:
+
+```
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_versions = {
+        "": "15.0.6",
+        "darwin-aarch64": "15.0.7",
+        "darwin-x86_64": "15.0.7",
+    },
+)
+```
 
 #### Customizations
 

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -55,6 +55,16 @@ llvm_toolchain(
     },
 )
 
+# The following automatically gets the full archive details from llvm_distributions.bzl.
+llvm_toolchain(
+    name = "llvm_toolchain_auto",
+    llvm_versions = {
+        "": "15.0.6",
+        "darwin-aarch64": "15.0.7",
+        "darwin-x86_64": "15.0.7",
+    },
+)
+
 # This is the latest version of LLVM that seems to work with rules_go; later
 # versions cause the tests to crash.
 llvm_toolchain(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -27,12 +27,23 @@ bazel_toolchain_dependencies()
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 # When updating this version, also update the versions associated with
-# llvm_toolchain below, sys_paths_test in the worflows file, and xcompile_test
+# llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
 LLVM_VERSION = "15.0.6"
 
 llvm_toolchain(
     name = "llvm_toolchain",
+    llvm_versions = {
+        "": "15.0.6",
+        "darwin-aarch64": "15.0.7",
+        "darwin-x86_64": "15.0.7",
+    },
+)
+
+# Example toolchain with user provided URLs.
+# TODO(siddharthab): Add test.
+llvm_toolchain(
+    name = "llvm_toolchain_with_urls",
     llvm_versions = {
         "": "15.0.6",
         "darwin-aarch64": "15.0.7",
@@ -52,16 +63,6 @@ llvm_toolchain(
         "": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz"],
         "darwin-aarch64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-arm64-apple-darwin22.0.tar.xz"],
         "darwin-x86_64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz"],
-    },
-)
-
-# The following automatically gets the full archive details from llvm_distributions.bzl.
-llvm_toolchain(
-    name = "llvm_toolchain_auto",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-aarch64": "15.0.7",
-        "darwin-x86_64": "15.0.7",
     },
 )
 

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -338,8 +338,8 @@ def _get_llvm_version(rctx):
     if rctx.attr.llvm_version:
         return rctx.attr.llvm_version
     if not rctx.attr.llvm_versions:
-        fail("Neither 'llvm_version' not 'llvm_versions' given.")
-    (key, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions")
+        fail("Neither 'llvm_version' nor 'llvm_versions' given.")
+    (key, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions", debug=True)
     if not llvm_version:
         fail("LLVM version string missing for ({os}, {arch})", os=_os(rctx), arch=_arch(rctx))
     return llvm_version

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
-load("//toolchain/internal:common.bzl", _arch = "arch", _attr_dict = "attr_dict", _host_os_arch_dict_value = "host_os_arch_dict_value")
+load("//toolchain/internal:common.bzl", _arch = "arch", _attr_dict = "attr_dict", _host_os_arch_dict_value = "host_os_arch_dict_value", _os = "os")
 load("//toolchain/internal:release_name.bzl", _llvm_release_name = "llvm_release_name")
 
 # If a new LLVM version is missing from this list, please add the shasums here
@@ -334,8 +334,18 @@ def _urls(rctx):
 
     return urls, sha256, strip_prefix, key
 
+def _get_llvm_version(rctx):
+    if rctx.attr.llvm_version:
+        return rctx.attr.llvm_version
+    if not rctx.attr.llvm_versions:
+        fail("Neither 'llvm_version' not 'llvm_versions' given.")
+    (key, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions")
+    if not llvm_version:
+        fail("LLVM version string missing for ({os}, {arch})", os=_os(rctx), arch=_arch(rctx))
+    return llvm_version
+
 def _distribution_urls(rctx):
-    llvm_version = rctx.attr.llvm_version
+    llvm_version = _get_llvm_version(rctx)
 
     if rctx.attr.distribution == "auto":
         basename = _llvm_release_name(rctx, llvm_version)

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -339,7 +339,7 @@ def _get_llvm_version(rctx):
         return rctx.attr.llvm_version
     if not rctx.attr.llvm_versions:
         fail("Neither 'llvm_version' nor 'llvm_versions' given.")
-    (key, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions", debug=True)
+    (key, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions")
     if not llvm_version:
         fail("LLVM version string missing for ({os}, {arch})", os=_os(rctx), arch=_arch(rctx))
     return llvm_version

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -31,13 +31,12 @@ _target_pairs = ", ".join(_supported_os_arch_keys())
 _common_attrs = {
     "llvm_versions": attr.string_dict(
         mandatory = False,
-        doc = ("LLVM version strings that map os-arch to versions with the empty key " +
-               "defining the default version in case the os-arch target has not been " +
-               "specified explicitly. This allows to define a base version and specifc " +
-               "target versions for targets that require a differnt version. " +
+        doc = ("LLVM version strings, keyed by host OS release name and architecture, " +
+               "e.g. darwin-x86_64, darwin-aarch64, ubuntu-20.04-x86_64, etc., or a " +
+               "less specific OS and arch pair ({}). ".format(_target_pairs) +
+               "An empty key is used to specify a fallback default for all hosts. " +
                "If no `toolchain_roots` is given, then the toolchain will be looked up " +
-               "in the list of known llvm_distributions using the identified target " +
-               "and the provided version. " +
+               "in the list of known llvm_distributions using the provided version. " +
                "If unset, a default value is set from the `llvm_version` attribute."),
     ),
 }
@@ -53,7 +52,7 @@ _llvm_repo_attrs.update({
         mandatory = False,
         doc = ("URLs to LLVM pre-built binary distribution archives, keyed by host OS " +
                "release name and architecture, e.g. darwin-x86_64, darwin-aarch64, " +
-               "ubuntu-20.04-x86_64, etc, or a less specific OS and arch pair " +
+               "ubuntu-20.04-x86_64, etc., or a less specific OS and arch pair " +
                "({}). ".format(_target_pairs) +
                "May also need the `strip_prefix` attribute. " +
                "Consider also setting the `sha256` attribute. An empty key is " +

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -29,6 +29,17 @@ _target_pairs = ", ".join(_supported_os_arch_keys())
 
 # Atributes common to both `llvm` and `toolchain` repository rules.
 _common_attrs = {
+    "llvm_versions": attr.string_dict(
+        mandatory = False,
+        doc = ("LLVM version strings that map os-arch to versions with the empty key " +
+               "defining the default version in case the os-arch target has not been " +
+               "specified explicitly. This allows to define a base version and specifc " +
+               "target versions for targets that require a differnt version. " +
+               "If no `toolchain_roots` is given, then the toolchain will be looked up " +
+               "in the list of known llvm_distributions using the identified target " +
+               "and the provided version. " +
+               "If unset, a default value is set from the `llvm_version` attribute."),
+    ),
 }
 
 _llvm_repo_attrs = dict(_common_attrs)
@@ -238,11 +249,6 @@ _llvm_config_attrs.update({
                "assumed to be a system path and the toolchain is configured to use absolute " +
                "paths. Else, the value will be assumed to be a bazel package containing the " +
                "filegroup targets as in BUILD.llvm_repo."),
-    ),
-    "llvm_versions": attr.string_dict(
-        mandatory = True,
-        doc = ("LLVM version strings for each entry in the `toolchain_roots` attribute; " +
-               "if unset, a default value is set from the `llvm_version` attribute."),
     ),
     "absolute_paths": attr.bool(
         default = False,


### PR DESCRIPTION
Allow `llvm_toolchain` to use attribute `llvm_verions` to provide a target/version mapping. This
allows to refer to the distributions configured in `llvm_distributions.bzl`.

This way users can provide the exact mapping they require for all
targets they want to support. For instance:

llvm_toolchain(
    name = "llvm_toolchain",
    llvm_versions = {
        "": "15.0.6",
        "darwin-aarch64": "15.0.7",
        "darwin-x86_64": "15.0.7",
    },
)