### PR TITLE
fix: remove use of label ctor in repo rule impl to avoid restarts

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -189,7 +189,7 @@ def llvm_register_toolchains():
     # Convenience macro to register all generated toolchains.
     rctx.template(
         "toolchains.bzl",
-        Label("//toolchain:toolchains.bzl.tpl"),
+        rctx.attr._toolchains_bzl_tpl,
         {
             "%{toolchain_labels}": toolchain_labels_str,
         },
@@ -198,7 +198,7 @@ def llvm_register_toolchains():
     # BUILD file with all the generated toolchain definitions.
     rctx.template(
         "BUILD.bazel",
-        Label("//toolchain:BUILD.toolchain.tpl"),
+        rctx.attr._build_toolchain_tpl,
         {
             "%{cc_toolchain_config_bzl}": str(rctx.attr._cc_toolchain_config_bzl),
             "%{cc_toolchains}": cc_toolchains_str,
@@ -210,12 +210,12 @@ def llvm_register_toolchains():
 
     # CC wrapper script; see comments near the definition of `wrapper_bin_prefix`.
     if os == "darwin":
-        cc_wrapper_tpl = "//toolchain:osx_cc_wrapper.sh.tpl"
+        cc_wrapper_tpl = rctx.attr._darwin_cc_wrapper_sh_tpl
     else:
-        cc_wrapper_tpl = "//toolchain:cc_wrapper.sh.tpl"
+        cc_wrapper_tpl = rctx.attr._cc_wrapper_sh_tpl
     rctx.template(
         "bin/cc_wrapper.sh",
-        Label(cc_wrapper_tpl),
+        cc_wrapper_tpl,
         {
             "%{toolchain_path_prefix}": llvm_dist_path_prefix,
         },
@@ -224,7 +224,7 @@ def llvm_register_toolchains():
     # libtool wrapper; used if the host libtool doesn't support arg files:
     rctx.template(
         "bin/host_libtool_wrapper.sh",
-        Label("//toolchain:host_libtool_wrapper.sh.tpl"),
+        rctx.attr._host_libtool_wrapper_sh_tpl,
         {
             "%{libtool_path}": "/usr/bin/libtool",
         },

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -256,6 +256,21 @@ _llvm_config_attrs.update({
     "_cc_toolchain_config_bzl": attr.label(
         default = "//toolchain:cc_toolchain_config.bzl",
     ),
+    "_toolchains_bzl_tpl": attr.label(
+        default = "//toolchain:toolchains.bzl.tpl",
+    ),
+    "_build_toolchain_tpl": attr.label(
+        default = "//toolchain:BUILD.toolchain.tpl",
+    ),
+    "_darwin_cc_wrapper_sh_tpl": attr.label(
+        default = "//toolchain:osx_cc_wrapper.sh.tpl",
+    ),
+    "_cc_wrapper_sh_tpl": attr.label(
+        default = "//toolchain:cc_wrapper.sh.tpl",
+    ),
+    "_host_libtool_wrapper_sh_tpl": attr.label(
+        default = "//toolchain:host_libtool_wrapper.sh.tpl",
+    ),
 })
 
 llvm = repository_rule(


### PR DESCRIPTION
Removes the use of the `Label` constructor used for templating with a predeclared dependency on the files as private rule attrs. This removes the need for Skyframe to restart the rule each time a new dependency is encountered during the running of the repository rule.

From running `bazel test //...` in the test directory before this change:
 
<img width="1121" alt="Screen Shot 2023-05-24 at 3 46 43 PM" src="https://github.com/grailbio/bazel-toolchain/assets/2403720/e00e7357-eb24-4bd5-9930-708ea72546dc">

Where as the profile after shows just the single invocation.

This is a similar issue we caught in rules_nodejs, https://github.com/bazelbuild/rules_nodejs/pull/2621 and there's further context in https://github.com/bazelbuild/bazel/issues/16162