### PR TITLE
Simplify test docker image dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        script: [archlinux, debian, fedora, suse_leap, suse_tumbleweed, ubuntu_18_04, ubuntu_20_04, linux_sysroot]
+        script: [archlinux, debian, fedora, suse_leap, suse_tumbleweed, ubuntu_20_04, ubuntu_22_04, linux_sysroot]
     steps:
     - uses: actions/checkout@v2
     - name: test

--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -30,9 +30,6 @@ for image in "${images[@]}"; do
   docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
-# Install dependencies
-pacman -Syu --noconfirm --quiet python
-
 # Run tests
 cd /src
 tests/scripts/run_tests.sh -t ${toolchain}

--- a/tests/scripts/debian_test.sh
+++ b/tests/scripts/debian_test.sh
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install apt-utils curl pkg-config zip zlib1g-dev unzip python gnupg2 libtinfo5 >/dev/null
+apt-get -qq -y install curl zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 

--- a/tests/scripts/linux_sysroot_test.sh
+++ b/tests/scripts/linux_sysroot_test.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 images=(
-"ubuntu:20.04"
+"ubuntu:22.04"
 )
 
 git_root=$(git rev-parse --show-toplevel)
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install apt-utils curl pkg-config zip g++ zlib1g-dev unzip python >/dev/null
+apt-get -qq -y install curl zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 

--- a/tests/scripts/suse_leap_test.sh
+++ b/tests/scripts/suse_leap_test.sh
@@ -34,7 +34,7 @@ set -exuo pipefail
 
 # Common setup
 zypper -n update
-zypper -n install curl python tar gzip gcc libc++1 libncurses5 binutils-gold
+zypper -n install curl gcc libc++1
 
 # Run tests
 cd /src

--- a/tests/scripts/suse_tumbleweed_test.sh
+++ b/tests/scripts/suse_tumbleweed_test.sh
@@ -34,7 +34,7 @@ set -exuo pipefail
 
 # Common setup
 zypper -n update
-zypper -n install pkgconf-pkg-config curl python tar gzip findutils gcc libc++1 libncurses5 binutils-gold
+zypper -n install curl gcc libc++1
 
 # Run tests
 cd /src

--- a/tests/scripts/ubuntu_22_04_test.sh
+++ b/tests/scripts/ubuntu_22_04_test.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 images=(
-"ubuntu:18.04"
+"ubuntu:22.04"
 )
 
 git_root=$(git rev-parse --show-toplevel)
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install apt-utils curl pkg-config zip zlib1g-dev unzip python >/dev/null
+apt-get -qq -y install curl zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 


### PR DESCRIPTION
Current Bazel versions have simplified runtime dependencies in modern OS versions.