### PR TITLE
Use llvm-ar on darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,14 @@ load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
 llvm_register_toolchains()
 ```
 
-And add the following section to your .bazelrc file (not needed after
-this [issue](https://github.com/bazelbuild/bazel/issues/7260) is closed):
+And add the following section to your .bazelrc file:
 ```
+# Not needed after https://github.com/bazelbuild/bazel/issues/7260 is closed
 build --incompatible_enable_cc_toolchain_resolution
+
+# Tell Bazel to pass the right flags for llvm-ar, not libtool. Only needed if you are building on darwin.
+# See https://github.com/bazelbuild/bazel/blob/5c75d0acec21459bbb13520817e3806e1507e907/tools/cpp/unix_cc_toolchain_config.bzl#L1000-L1024
+build --features=-libtool
 ```
 
 ## Basic Usage

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -294,15 +294,10 @@ def cc_toolchain_config(
     ## NOTE: make variables are missing here; unix_cc_toolchain_config doesn't
     ## pass these to `create_cc_toolchain_config_info`.
 
-    # TODO: The command line formed on darwin does not work with llvm-ar.
-    ar_binary = tools_path_prefix + "llvm-ar"
-    if host_os == "darwin":
-        ar_binary = host_tools_info["libtool"]["path"]
-
     # The tool names come from [here](https://github.com/bazelbuild/bazel/blob/c7e58e6ce0a78fdaff2d716b4864a5ace8917626/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java#L76-L90):
     # NOTE: Ensure these are listed in toolchain_tools in toolchain/internal/common.bzl.
     tool_paths = {
-        "ar": ar_binary,
+        "ar": tools_path_prefix + "llvm-ar",
         "cpp": tools_path_prefix + "clang-cpp",
         "dwp": tools_path_prefix + "llvm-dwp",
         "gcc": wrapper_bin_prefix + "cc_wrapper.sh",

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -153,8 +153,6 @@ def llvm_register_toolchains():
     host_tools_info = dict([
         pair
         for (key, tool_path) in [
-            # This is used for macOS hosts:
-            ("libtool", "/usr/bin/libtool"),
             # This is used when lld doesn't support the target platform (i.e.
             # Mach-O for macOS):
             ("ld", "/usr/bin/ld"),


### PR DESCRIPTION
This avoids another non-hermetic dependency on the host and brings linux/darwin builds closer in line.