### PR TITLE
Update LLVM versions in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,10 +97,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download and Extract LLVM distribution
         env:
-          release: llvmorg-15.0.6
-          archive: clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04
+          release: llvmorg-16.0.0
+          archive: clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04
           ext: .tar.xz
-          local_path: /tmp/llvm-15
+          local_path: /tmp/llvm-16
         run: wget --no-verbose "https://github.com/llvm/llvm-project/releases/download/${release}/${archive}${ext}" && tar -xf "${archive}${ext}" && mv "${archive}" "${local_path}"
       - name: Test
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,9 @@ jobs:
             bzlmod: false
     runs-on: ${{ matrix.os }}
     steps:
+      - if: startsWith(matrix.os, 'ubuntu')
+        name: Install APT packages
+        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v3
       - name: Test
         env:
@@ -53,6 +56,9 @@ jobs:
         bzlmod: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
+      - if: startsWith(matrix.os, 'ubuntu')
+        name: Install APT packages
+        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v3
       - name: Test
         env:
@@ -88,12 +94,16 @@ jobs:
   abs_paths_test:
     runs-on: ubuntu-latest
     steps:
+      - name: Install APT packages
+        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v3
       - name: Test
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_absolute_paths//:cc-toolchain-x86_64-linux
   sys_paths_test:
     runs-on: ubuntu-latest
     steps:
+      - name: Install APT packages
+        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v3
       - name: Download and Extract LLVM distribution
         env:

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -76,14 +76,15 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
 LLVM_VERSION = "15.0.6"
+LLVM_VERSIONS = {
+    "": "16.0.0",
+    "darwin-aarch64": "16.0.5",
+    "darwin-x86_64": "15.0.7",
+}
 
 llvm.toolchain(
     name = "llvm_toolchain",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-aarch64": "15.0.7",
-        "darwin-x86_64": "15.0.7",
-    },
+    llvm_versions = LLVM_VERSIONS,
 )
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 
@@ -144,7 +145,7 @@ llvm.toolchain(
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     # A path in /tmp to be part of system tmp cleanup schedule.
-    toolchain_roots = {"": "/tmp/llvm-15"},
+    toolchain_roots = {"": "/tmp/llvm-16"},
 )
 use_repo(llvm, "llvm_toolchain_with_system_llvm")
 
@@ -152,11 +153,7 @@ use_repo(llvm, "llvm_toolchain_with_system_llvm")
 
 llvm.toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-x86_64": "15.0.7",
-        "darwin-aarch64": "15.0.7",
-    },
+    llvm_versions = LLVM_VERSIONS,
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
     },

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -29,26 +29,24 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 # When updating this version, also update the versions associated with
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
-LLVM_VERSION = "15.0.6"
+LLVM_VERSION = "16.0.0"
+
+LLVM_VERSIONS = {
+    "": "16.0.0",
+    "darwin-aarch64": "16.0.5",
+    "darwin-x86_64": "15.0.7",
+}
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-aarch64": "15.0.7",
-        "darwin-x86_64": "15.0.7",
-    },
+    llvm_versions = LLVM_VERSIONS,
 )
 
 # Example toolchain with user provided URLs.
 # TODO(siddharthab): Add test.
 llvm_toolchain(
     name = "llvm_toolchain_with_urls",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-aarch64": "15.0.7",
-        "darwin-x86_64": "15.0.7",
-    },
+    llvm_versions = LLVM_VERSIONS,
     sha256 = {
         "": "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036",
         "darwin-aarch64": "867c6afd41158c132ef05a8f1ddaecf476a26b91c85def8e124414f9a9ba188d",
@@ -96,7 +94,7 @@ llvm_toolchain(
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     # A path in /tmp to be part of system tmp cleanup schedule.
-    toolchain_roots = {"": "/tmp/llvm-15"},
+    toolchain_roots = {"": "/tmp/llvm-16"},
 )
 
 ## Toolchain example with a sysroot.
@@ -117,11 +115,7 @@ filegroup(
 
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = {
-        "": "15.0.6",
-        "darwin-x86_64": "15.0.7",
-        "darwin-aarch64": "15.0.7",
-    },
+    llvm_versions = LLVM_VERSIONS,
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
     },

--- a/tests/scripts/debian_test.sh
+++ b/tests/scripts/debian_test.sh
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install curl zlib1g-dev >/dev/null
+apt-get -qq -y install curl libtinfo5 zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 

--- a/tests/scripts/fedora_test.sh
+++ b/tests/scripts/fedora_test.sh
@@ -28,7 +28,7 @@ for image in "${images[@]}"; do
 set -exuo pipefail
 
 # Need system glibc headers (e.g. features.h).
-dnf install -qy glibc-headers
+dnf install -qy glibc-headers ncurses-compat-libs
 
 # Run tests
 cd /src

--- a/tests/scripts/linux_sysroot_test.sh
+++ b/tests/scripts/linux_sysroot_test.sh
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install curl zlib1g-dev >/dev/null
+apt-get -qq -y install curl libtinfo5 zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 

--- a/tests/scripts/ubuntu_20_04_test.sh
+++ b/tests/scripts/ubuntu_20_04_test.sh
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install apt-utils curl pkg-config zip zlib1g-dev unzip python >/dev/null
+apt-get -qq -y install apt-utils curl libtinfo5 pkg-config zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 

--- a/tests/scripts/ubuntu_22_04_test.sh
+++ b/tests/scripts/ubuntu_22_04_test.sh
@@ -30,7 +30,7 @@ set -exuo pipefail
 # Common setup
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq -y install curl zlib1g-dev >/dev/null
+apt-get -qq -y install curl libtinfo5 zlib1g-dev >/dev/null
 # The above command gives some verbose output that can not be silenced easily.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=288778
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -45,6 +45,7 @@ def cc_toolchain_config(
     host_os_arch_key = _os_arch_pair(host_os, host_arch)
     target_os_arch_key = _os_arch_pair(target_os, target_arch)
     _check_os_arch_keys([host_os_arch_key, target_os_arch_key])
+    major_llvm_version = int(llvm_version.split(".")[0])
 
     # A bunch of variables that get passed straight through to
     # `create_cc_toolchain_config_info`.
@@ -269,6 +270,9 @@ def cc_toolchain_config(
             toolchain_path_prefix + "lib/clang/{}/include".format(llvm_version),
             toolchain_path_prefix + "lib/clang/{}/share".format(llvm_version),
             toolchain_path_prefix + "lib64/clang/{}/include".format(llvm_version),
+            toolchain_path_prefix + "lib/clang/{}/include".format(major_llvm_version),
+            toolchain_path_prefix + "lib/clang/{}/share".format(major_llvm_version),
+            toolchain_path_prefix + "lib64/clang/{}/include".format(major_llvm_version),
         ])
 
     sysroot_path = compiler_configuration["sysroot_path"]


### PR DESCRIPTION
Updates LLVM to 16.0.0 as default, 16.0.5 for Apple Silicon, but keeps 15.0.7 for x86 Apple.