### PR TITLE
Avoid calling xcrun on darwin if we don't need to

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -126,7 +126,6 @@ def llvm_register_toolchains():
         rctx.attr.sysroot,
         use_absolute_paths_sysroot,
     )
-    default_sysroot_path = _default_sysroot_path(rctx, os)
 
     workspace_name = rctx.name
     toolchain_info = struct(
@@ -138,7 +137,6 @@ def llvm_register_toolchains():
         wrapper_bin_prefix = wrapper_bin_prefix,
         sysroot_paths_dict = sysroot_paths_dict,
         sysroot_labels_dict = sysroot_labels_dict,
-        default_sysroot_path = default_sysroot_path,
         target_settings_dict = rctx.attr.target_settings,
         additional_include_dirs_dict = rctx.attr.cxx_builtin_include_directories,
         stdlib_dict = rctx.attr.stdlib,
@@ -166,6 +164,7 @@ def llvm_register_toolchains():
         for pair in _host_tools.get_tool_info(rctx, tool_path, key).items()
     ])
     cc_toolchains_str, toolchain_labels_str = _cc_toolchains_str(
+        rctx,
         workspace_name,
         toolchain_info,
         use_absolute_paths_llvm,
@@ -216,6 +215,7 @@ def llvm_register_toolchains():
     )
 
 def _cc_toolchains_str(
+        rctx,
         workspace_name,
         toolchain_info,
         use_absolute_paths_llvm,
@@ -238,6 +238,7 @@ def _cc_toolchains_str(
     for (target_os, target_arch) in _supported_targets:
         suffix = "{}-{}".format(target_arch, target_os)
         cc_toolchain_str = _cc_toolchain_str(
+            rctx,
             suffix,
             target_os,
             target_arch,
@@ -261,6 +262,7 @@ def _dict_value(d, target_pair, default = None):
     return d.get(target_pair, d.get("", default))
 
 def _cc_toolchain_str(
+        rctx,
         suffix,
         target_os,
         target_arch,
@@ -285,7 +287,7 @@ def _cc_toolchain_str(
     if not sysroot_path:
         if host_os == target_os and host_arch == target_arch:
             # For darwin -> darwin, we can use the macOS SDK path.
-            sysroot_path = toolchain_info.default_sysroot_path
+            sysroot_path = _default_sysroot_path(rctx, host_os)
         else:
             # We are trying to cross-compile without a sysroot, let's bail.
             # TODO: Are there situations where we can continue?


### PR DESCRIPTION
Calling xcrun can actually fail if you don't have xcode installed or haven't accepted the license/etc. If the user provides an explicit sysroot, we will never use the default one so this failure is unfortunate. Defer computing the default until we need it.