### PR TITLE
[TECH-5948] librdkafka needs libraries from system :(

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -157,6 +157,18 @@ def cc_toolchain_config(
             "-headerpad_max_install_names",
             "-fobjc-link-runtime",
         ])
+        # (david) custom changes to expose important system libs. womp womp.
+        # TODO: clean these up if we ever find a way
+        link_flags.extend([
+            "-lxml2",
+            "-lcurl",
+            "-lm",
+            "-lsasl2",
+            "-lz",
+            "-ldl",
+            "-lpthread",
+        ])
+
     else:
         # Note that for xcompiling from darwin to linux, the native ld64 is
         # not an option because it is not a cross-linker, so lld is the


### PR DESCRIPTION
Unfortunately, these libraries must be provided by the operating system in order to link against librdkafka. Without these, many symbols will be undefined at link time, leading to build failures. 

We'll probably also want to document the process for installing these libraries or bundle it into the machine setup repo.