### PR TITLE
Add `extra_compiler_files` attribute to make suppression files available to sanitizers during compilation

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -152,6 +152,7 @@ def llvm_register_toolchains():
         coverage_link_flags_dict = rctx.attr.coverage_link_flags,
         unfiltered_compile_flags_dict = rctx.attr.unfiltered_compile_flags,
         llvm_version = llvm_version,
+        extra_compiler_files = rctx.attr.extra_compiler_files,
     )
     host_dl_ext = "dylib" if os == "darwin" else "so"
     host_tools_info = dict([
@@ -293,6 +294,10 @@ def _cc_toolchain_str(
             # TODO: Are there situations where we can continue?
             return ""
 
+    extra_compiler_files = ""
+    if toolchain_info.extra_compiler_files:
+        extra_compiler_files = '"{}",'.format(toolchain_info.extra_compiler_files)
+
     extra_files_str = "\":internal-use-files\""
 
     # `struct` isn't allowed in `BUILD` files so we JSON encode + decode to turn
@@ -358,7 +363,10 @@ filegroup(
         template = template + """
 filegroup(
     name = "compiler-components-{suffix}",
-    srcs = [":sysroot-components-{suffix}"],
+    srcs = [
+        ":sysroot-components-{suffix}"
+        {extra_compiler_files}
+    ],
 )
 
 filegroup(
@@ -391,6 +399,7 @@ filegroup(
         "{llvm_dist_label_prefix}clang",
         "{llvm_dist_label_prefix}include",
         ":sysroot-components-{suffix}",
+        {extra_compiler_files}
     ],
 )
 
@@ -468,6 +477,7 @@ cc_toolchain(
         coverage_link_flags = _list_to_string(_dict_value(toolchain_info.coverage_link_flags_dict, target_pair)),
         unfiltered_compile_flags = _list_to_string(_dict_value(toolchain_info.unfiltered_compile_flags_dict, target_pair)),
         llvm_version = toolchain_info.llvm_version,
+        extra_compiler_files = extra_compiler_files,
         extra_files_str = extra_files_str,
         host_tools_info = host_tools_info,
     )

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -225,6 +225,13 @@ _compiler_configuration_attrs = {
         mandatory = False,
         doc = ("Override the toolchain's `target_settings` attribute."),
     ),
+    "extra_compiler_files": attr.string(
+        mandatory = False,
+        doc = ("Extra label to add to the srcs of the filegroup that for the toolchain's " +
+               "compiler_files attr. It will be available for compile actions. " +
+               "Useful for sanitizer compile-time ignorelists. " +
+               "Example: \"@@//sanitizers:ignorelist.txt\""),
+    ),
 }
 
 llvm_config_attrs = dict(common_attrs)


### PR DESCRIPTION
I'm adding sanitizers into our build and I need the compilation action to have access to the sanitizer blacklist.

```
# In MODULE.bazel
llvm.toolchain(
    name = "llvm_toolchain",
    (...)
    extra_compiler_files = "@@//tools/sanitizers:compiletime_ignorelist.txt",
)
```

```
# In .bazelrc
build:sanitizers --copt -fsanitize-ignorelist=tools/sanitizers/compiletime_ignorelist.txt
```

The compiletime_ignorelist.txt is a https://releases.llvm.org/17.0.1/tools/clang/docs/SanitizerSpecialCaseList.html

This is a draft PR because
* No tests -- it's a simple addition though and it works in my repo, so maybe that's ok :blush: 
* It currently doesn't work with rules_foreign_cc: `clang: error: no such file or directory: 'tools/sanitizers/compiletime_ignorelist.txt'` Still need to debug that one (or give up and find a way to not enable sanitizers on those targets)

I'd like to hear feedback if you think this is a good idea, maybe there are better alternatives?