### PR TITLE
Add support for `layering_check`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
           release: llvmorg-16.0.0
           archive: clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04
           ext: .tar.xz
-          local_path: /tmp/llvm-16
+          local_path: /opt/llvm-16
         run: wget --no-verbose "https://github.com/llvm/llvm-project/releases/download/${release}/${archive}${ext}" && tar -xf "${archive}${ext}" && mv "${archive}" "${local_path}"
       - name: Test
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux

--- a/README.md
+++ b/README.md
@@ -239,6 +239,19 @@ then they can be referenced as:
 - `@llvm_toolchain//:clang-format`
 - `@llvm_toolchain//:llvm-cov`
 
+### Strict header deps (Linux only)
+
+The toolchain supports Bazel's `layering_check` feature, which relies on
+[Clang modules](https://clang.llvm.org/docs/Modules.html) to implement strict
+deps (also known as "depend on what you use") for `cc_*` rules. This features
+can be enabled by enabling the `layering_check` feature on a per-target,
+per-package or global basis.
+
+If one of toolchain or sysroot are specified via an absolute path rather than
+managed by Bazel, the `layering_check` feature may require running
+`bazel clean --expunge` after making changes to the set of header files
+installed on the host.
+
 ## Prior Art
 
 Other examples of toolchain configuration:

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ then they can be referenced as:
 
 The toolchain supports Bazel's `layering_check` feature, which relies on
 [Clang modules](https://clang.llvm.org/docs/Modules.html) to implement strict
-deps (also known as "depend on what you use") for `cc_*` rules. This features
+deps (also known as "depend on what you use") for `cc_*` rules. This feature
 can be enabled by enabling the `layering_check` feature on a per-target,
 per-package or global basis.
 

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,1 +1,2 @@
 build --incompatible_enable_cc_toolchain_resolution
+build --features=layering_check

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,5 +1,2 @@
 build --incompatible_enable_cc_toolchain_resolution
 build --features=layering_check
-
-# Temporary workaround for bugs in Bazel 7.0.0.
-build --noincompatible_sandbox_hermetic_tmp

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,2 +1,5 @@
 build --incompatible_enable_cc_toolchain_resolution
 build --features=layering_check
+
+build --noincompatible_sandbox_hermetic_tmp
+build --noexperimental_enable_bzlmod

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,4 +1,5 @@
 build --incompatible_enable_cc_toolchain_resolution
 build --features=layering_check
 
+# Temporary workaround for bugs in Bazel 7.0.0.
 build --noincompatible_sandbox_hermetic_tmp

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -2,4 +2,3 @@ build --incompatible_enable_cc_toolchain_resolution
 build --features=layering_check
 
 build --noincompatible_sandbox_hermetic_tmp
-build --noexperimental_enable_bzlmod

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -31,10 +31,10 @@ bazel_dep(name = "rules_rust", version = "0.27.0")
 bazel_dep(name = "abseil-cpp", repo_name = "com_google_absl")
 archive_override(
     module_name = "abseil-cpp",
-    integrity = "sha256-4c3q1DMUJmjzz0ldlHdYT0Bv0rZoxTNuJqIguoQt5Vw=",
+    integrity = "sha256-y4VIbqbtC5jid7maB/QbWfwl9Yu0IZrDWaXGqQipvmk=",
     patches = ["//patches:abseil-cpp.patch"],
-    strip_prefix = "abseil-cpp-0ef3ef432996de4c5afa879b93b2ba4f6c130ab2",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/0ef3ef432996de4c5afa879b93b2ba4f6c130ab2.tar.gz"],
+    strip_prefix = "abseil-cpp-b2dd3a5be797f8194bbc230c65f35aadd3998535",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/b2dd3a5be797f8194bbc230c65f35aadd3998535.tar.gz"],
 )
 
 # Temporary override until newer version is released to the central registry.

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -77,6 +77,7 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
 LLVM_VERSION = "15.0.6"
+
 LLVM_VERSIONS = {
     "": "16.0.0",
     "darwin-aarch64": "16.0.5",
@@ -156,11 +157,13 @@ llvm.toolchain(
     name = "llvm_toolchain_with_sysroot",
     llvm_versions = LLVM_VERSIONS,
     sysroot = {
-        "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
+        # TODO: Use an apparent repo name after #234 has been fixed.
+        "linux-x86_64": "@@org_chromium_sysroot_linux_x64//:sysroot",
     },
     # We can share the downloaded LLVM distribution with the first configuration.
     toolchain_roots = {
-        "": "@llvm_toolchain_llvm//",
+        # TODO: Use an apparent repo name after #234 has been fixed.
+        "": "@@toolchains_llvm~override~llvm~llvm_toolchain_llvm//",
     },
 )
 use_repo(llvm, "llvm_toolchain_with_sysroot")

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -53,6 +53,14 @@ git_override(
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 
+# Temporary override until newer version is released to the central registry.
+# https://github.com/bazelbuild/rules_go/commit/31549c1f0fbe850aee3d2b7dd7a1303952f7cd75
+git_override(
+    module_name = "rules_go",
+    commit = "31549c1f0fbe850aee3d2b7dd7a1303952f7cd75",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+)
+
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -154,7 +154,6 @@ llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
-    # A path in /tmp to be part of system tmp cleanup schedule.
     toolchain_roots = {"": "/opt/llvm-16"},
 )
 use_repo(llvm, "llvm_toolchain_with_system_llvm")

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -155,7 +155,7 @@ llvm.toolchain(
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     # A path in /tmp to be part of system tmp cleanup schedule.
-    toolchain_roots = {"": "/tmp/llvm-16"},
+    toolchain_roots = {"": "/opt/llvm-16"},
 )
 use_repo(llvm, "llvm_toolchain_with_system_llvm")
 

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -31,9 +31,10 @@ bazel_dep(name = "rules_rust", version = "0.27.0")
 bazel_dep(name = "abseil-cpp", repo_name = "com_google_absl")
 archive_override(
     module_name = "abseil-cpp",
+    integrity = "sha256-4c3q1DMUJmjzz0ldlHdYT0Bv0rZoxTNuJqIguoQt5Vw=",
     patches = ["//patches:abseil-cpp.patch"],
-    strip_prefix = "abseil-cpp-20230125.3",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz"],
+    strip_prefix = "abseil-cpp-0ef3ef432996de4c5afa879b93b2ba4f6c130ab2",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/0ef3ef432996de4c5afa879b93b2ba4f6c130ab2.tar.gz"],
 )
 
 # Temporary override until newer version is released to the central registry.

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -94,7 +94,7 @@ llvm_toolchain(
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     # A path in /tmp to be part of system tmp cleanup schedule.
-    toolchain_roots = {"": "/tmp/llvm-16"},
+    toolchain_roots = {"": "/opt/llvm-16"},
 )
 
 ## Toolchain example with a sysroot.

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -93,7 +93,6 @@ llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
     llvm_version = LLVM_VERSION,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
-    # A path in /tmp to be part of system tmp cleanup schedule.
     toolchain_roots = {"": "/opt/llvm-16"},
 )
 

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -171,13 +171,13 @@ http_archive(
 
 # For testing rules_go.
 
+# Temporary override until newer version is released to the central registry.
+# https://github.com/bazelbuild/rules_go/commit/31549c1f0fbe850aee3d2b7dd7a1303952f7cd75
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-    ],
+    integrity = "sha256-8cixNZS5cm7qapSierAHoRQh8fA9dKMyFD5PBRvFgOY=",
+    strip_prefix = "rules_go-31549c1f0fbe850aee3d2b7dd7a1303952f7cd75",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/31549c1f0fbe850aee3d2b7dd7a1303952f7cd75.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -156,9 +156,9 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "91ac87d30cc6d79f9ab974c51874a704de9c2647c40f6932597329a282217ba8",
-    strip_prefix = "abseil-cpp-20220623.1",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.1.tar.gz"],
+    integrity = "sha256-4c3q1DMUJmjzz0ldlHdYT0Bv0rZoxTNuJqIguoQt5Vw=",
+    strip_prefix = "abseil-cpp-0ef3ef432996de4c5afa879b93b2ba4f6c130ab2",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/0ef3ef432996de4c5afa879b93b2ba4f6c130ab2.tar.gz"],
 )
 
 http_archive(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -156,9 +156,8 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    integrity = "sha256-4c3q1DMUJmjzz0ldlHdYT0Bv0rZoxTNuJqIguoQt5Vw=",
-    strip_prefix = "abseil-cpp-0ef3ef432996de4c5afa879b93b2ba4f6c130ab2",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/0ef3ef432996de4c5afa879b93b2ba4f6c130ab2.tar.gz"],
+    strip_prefix = "abseil-cpp-b2dd3a5be797f8194bbc230c65f35aadd3998535",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/b2dd3a5be797f8194bbc230c65f35aadd3998535.tar.gz"],
 )
 
 http_archive(

--- a/tests/openssl/openssl.bazel
+++ b/tests/openssl/openssl.bazel
@@ -864,6 +864,7 @@ cc_library(
 cc_library(
     name = "libssl",
     srcs = [
+        "e_os.h",
         "ssl/bio_ssl.c",
         "ssl/d1_lib.c",
         "ssl/d1_msg.c",

--- a/tests/patches/abseil-cpp.patch
+++ b/tests/patches/abseil-cpp.patch
@@ -1,13 +1,12 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -0,0 +1,10 @@
-+module(
-+    name = "abseil-cpp",
-+    version = "20230125.1",
-+    compatibility_level = 1,
-+)
-+bazel_dep(name = "rules_cc", version = "0.0.8")
-+bazel_dep(name = "platforms", version = "0.0.6")
-+bazel_dep(name = "bazel_skylib", version = "1.4.2")
-+bazel_dep(name = "googletest", version = "1.12.1", repo_name = "com_google_googletest")
-+bazel_dep(name = "google_benchmark", version = "1.8.3", repo_name = "com_github_google_benchmark")
+@@ -28,8 +28,7 @@ bazel_dep(name = "bazel_skylib",
+
+ bazel_dep(name = "google_benchmark",
+           version = "1.8.3",
+-          repo_name = "com_github_google_benchmark",
+-          dev_dependency = True)
++          repo_name = "com_github_google_benchmark")
+
+ bazel_dep(name = "googletest",
+           version = "1.14.0.bcr.1",

--- a/tests/patches/abseil-cpp.patch
+++ b/tests/patches/abseil-cpp.patch
@@ -1,6 +1,6 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,10 @@
 +module(
 +    name = "abseil-cpp",
 +    version = "20230125.1",
@@ -10,3 +10,4 @@
 +bazel_dep(name = "platforms", version = "0.0.6")
 +bazel_dep(name = "bazel_skylib", version = "1.4.2")
 +bazel_dep(name = "googletest", version = "1.12.1", repo_name = "com_google_googletest")
++bazel_dep(name = "google_benchmark", version = "1.8.3", repo_name = "com_github_google_benchmark")

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -24,7 +24,7 @@ cd "${scripts_dir}"
 # Generate some files needed for the tests.
 "${bazel}" query "${common_args[@]}" @io_bazel_rules_go//tests/core/cgo:dylib_test >/dev/null
 if [[ ${USE_BZLMOD} == "true" ]]; then
-  "$("${bazel}" info output_base)/external/rules_go~0.41.0/tests/core/cgo/generate_imported_dylib.sh"
+  "$("${bazel}" info output_base)/external/rules_go~override/tests/core/cgo/generate_imported_dylib.sh"
 else
   "$("${bazel}" info output_base)/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
 fi

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -55,5 +55,4 @@ absl_targets=($("${bazel}" query "${common_args[@]}" 'attr(timeout, short, tests
   -@io_bazel_rules_go//tests/core/cgo:cc_libs_test \
   -@io_bazel_rules_go//tests/core/cgo:external_includes_test \
   "${absl_targets[@]}" \
-  -@com_google_absl//absl/time/internal/cctz:time_zone_format_test \
-  -@com_google_absl//absl/time/internal/cctz:civil_time_test
+  -@com_google_absl//absl/time/internal/cctz:time_zone_format_test

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -32,6 +32,10 @@ fi
 test_args=(
   "${common_test_args[@]}"
   "--copt=-Wno-deprecated-builtins" # https://github.com/abseil/abseil-cpp/issues/1201
+  # Disable the "hermetic sandbox /tmp" behavior of Bazel 7 as it results in broken symlinks when
+  # rules_foreign_cc builds pcre.
+  # TODO: Remove this once rules_foreign_cc is fully compatible with Bazel 7.
+  "--sandbox_add_mount_pair=/tmp"
 )
 
 # We exclude the following targets:

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -55,4 +55,5 @@ absl_targets=($("${bazel}" query "${common_args[@]}" 'attr(timeout, short, tests
   -@io_bazel_rules_go//tests/core/cgo:cc_libs_test \
   -@io_bazel_rules_go//tests/core/cgo:external_includes_test \
   "${absl_targets[@]}" \
-  -@com_google_absl//absl/time/internal/cctz:time_zone_format_test
+  -@com_google_absl//absl/time/internal/cctz:time_zone_format_test \
+  -@com_google_absl//absl/time/internal/cctz:civil_time_test

--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
-load("//toolchain/internal:system_module_map.bzl", "system_module_map")
+load("@toolchains_llvm//toolchain/internal:system_module_map.bzl", "system_module_map")
 load("%{cc_toolchain_config_bzl}", "cc_toolchain_config")
 
 # Following filegroup targets are used when not using absolute paths and shared

--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
+load("//toolchain/internal:system_module_map.bzl", "system_module_map")
 load("%{cc_toolchain_config_bzl}", "cc_toolchain_config")
 
 # Following filegroup targets are used when not using absolute paths and shared

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -36,16 +36,16 @@ def cc_toolchain_config(
         host_os,
         target_arch,
         target_os,
+        target_system_name,
         toolchain_path_prefix,
         tools_path_prefix,
         wrapper_bin_prefix,
         compiler_configuration,
-        llvm_version,
+        cxx_builtin_include_directories,
         host_tools_info = {}):
     host_os_arch_key = _os_arch_pair(host_os, host_arch)
     target_os_arch_key = _os_arch_pair(target_os, target_arch)
     _check_os_arch_keys([host_os_arch_key, target_os_arch_key])
-    major_llvm_version = int(llvm_version.split(".")[0])
 
     # A bunch of variables that get passed straight through to
     # `create_cc_toolchain_config_info`.
@@ -53,7 +53,6 @@ def cc_toolchain_config(
     host_system_name = host_arch
     (
         toolchain_identifier,
-        target_system_name,
         target_cpu,
         target_libc,
         compiler,
@@ -62,7 +61,6 @@ def cc_toolchain_config(
     ) = {
         "darwin-x86_64": (
             "clang-x86_64-darwin",
-            "x86_64-apple-macosx",
             "darwin",
             "macosx",
             "clang",
@@ -71,7 +69,6 @@ def cc_toolchain_config(
         ),
         "darwin-aarch64": (
             "clang-aarch64-darwin",
-            "aarch64-apple-macosx",
             "darwin",
             "macosx",
             "clang",
@@ -80,7 +77,6 @@ def cc_toolchain_config(
         ),
         "linux-aarch64": (
             "clang-aarch64-linux",
-            "aarch64-unknown-linux-gnu",
             "aarch64",
             "glibc_unknown",
             "clang",
@@ -89,7 +85,6 @@ def cc_toolchain_config(
         ),
         "linux-x86_64": (
             "clang-x86_64-linux",
-            "x86_64-unknown-linux-gnu",
             "k8",
             "glibc_unknown",
             "clang",
@@ -175,6 +170,7 @@ def cc_toolchain_config(
     # always link C++ libraries.
     cxx_standard = compiler_configuration["cxx_standard"]
     stdlib = compiler_configuration["stdlib"]
+    sysroot_path = compiler_configuration["sysroot_path"]
     if stdlib == "builtin-libc++" and is_xcompile:
         stdlib = "stdc++"
     if stdlib == "builtin-libc++":
@@ -207,7 +203,7 @@ def cc_toolchain_config(
             # have the sysroot directory on the search path and then add the
             # toolchain directory back after we are done.
             link_flags.extend([
-                "-L{}/usr/lib".format(compiler_configuration["sysroot_path"]),
+                "-L{}/usr/lib".format(sysroot_path),
                 "-lc++",
                 "-lc++abi",
             ])
@@ -260,44 +256,6 @@ def cc_toolchain_config(
 
     ## NOTE: framework paths is missing here; unix_cc_toolchain_config
     ## doesn't seem to have a feature for this.
-
-    # C++ built-in include directories.
-    # This contains both the includes shipped with the compiler as well as the sysroot (or host)
-    # include directories. While Bazel's default undeclared inclusions check does not seem to be
-    # triggered by header files under the execroot, we still include those paths here as they are
-    # visible via the "built_in_include_directories" attribute of CcToolchainInfo as well as to keep
-    # them in sync with the directories included in the system module map generated for the stricter
-    # "layering_check" feature.
-    cxx_builtin_include_directories = [
-        toolchain_path_prefix + "include/c++/v1",
-        toolchain_path_prefix + "include/{}/c++/v1".format(target_system_name),
-        toolchain_path_prefix + "lib/clang/{}/include".format(llvm_version),
-        toolchain_path_prefix + "lib/clang/{}/share".format(llvm_version),
-        toolchain_path_prefix + "lib64/clang/{}/include".format(llvm_version),
-        toolchain_path_prefix + "lib/clang/{}/include".format(major_llvm_version),
-        toolchain_path_prefix + "lib/clang/{}/share".format(major_llvm_version),
-        toolchain_path_prefix + "lib64/clang/{}/include".format(major_llvm_version),
-    ]
-
-    sysroot_path = compiler_configuration["sysroot_path"]
-    sysroot_prefix = ""
-    if sysroot_path:
-        sysroot_prefix = "%sysroot%"
-    if target_os == "linux":
-        cxx_builtin_include_directories.extend([
-            sysroot_prefix + "/include",
-            sysroot_prefix + "/usr/include",
-            sysroot_prefix + "/usr/local/include",
-        ])
-    elif target_os == "darwin":
-        cxx_builtin_include_directories.extend([
-            sysroot_prefix + "/usr/include",
-            sysroot_prefix + "/System/Library/Frameworks",
-        ])
-    else:
-        fail("Unreachable")
-
-    cxx_builtin_include_directories.extend(compiler_configuration["additional_include_dirs"])
 
     ## NOTE: make variables are missing here; unix_cc_toolchain_config doesn't
     ## pass these to `create_cc_toolchain_config_info`.

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -22,6 +22,10 @@ load(
     _host_tools = "host_tools",
     _os_arch_pair = "os_arch_pair",
 )
+load(
+    "//toolchain/internal:system_module_map.bzl",
+    "system_module_map",
+)
 
 # Bazel 4.* doesn't support nested starlark functions, so we cannot simplify
 # _fmt_flags() by defining it as a nested function.
@@ -41,6 +45,7 @@ def cc_toolchain_config(
         wrapper_bin_prefix,
         compiler_configuration,
         llvm_version,
+        all_files,
         host_tools_info = {}):
     host_os_arch_key = _os_arch_pair(host_os, host_arch)
     target_os_arch_key = _os_arch_pair(target_os, target_arch)
@@ -262,18 +267,16 @@ def cc_toolchain_config(
     ## doesn't seem to have a feature for this.
 
     # C++ built-in include directories:
-    cxx_builtin_include_directories = []
-    if toolchain_path_prefix.startswith("/"):
-        cxx_builtin_include_directories.extend([
-            toolchain_path_prefix + "include/c++/v1",
-            toolchain_path_prefix + "include/{}/c++/v1".format(target_system_name),
-            toolchain_path_prefix + "lib/clang/{}/include".format(llvm_version),
-            toolchain_path_prefix + "lib/clang/{}/share".format(llvm_version),
-            toolchain_path_prefix + "lib64/clang/{}/include".format(llvm_version),
-            toolchain_path_prefix + "lib/clang/{}/include".format(major_llvm_version),
-            toolchain_path_prefix + "lib/clang/{}/share".format(major_llvm_version),
-            toolchain_path_prefix + "lib64/clang/{}/include".format(major_llvm_version),
-        ])
+    cxx_builtin_include_directories = [
+        toolchain_path_prefix + "include/c++/v1",
+        toolchain_path_prefix + "include/{}/c++/v1".format(target_system_name),
+        toolchain_path_prefix + "lib/clang/{}/include".format(llvm_version),
+        toolchain_path_prefix + "lib/clang/{}/share".format(llvm_version),
+        toolchain_path_prefix + "lib64/clang/{}/include".format(llvm_version),
+        toolchain_path_prefix + "lib/clang/{}/include".format(major_llvm_version),
+        toolchain_path_prefix + "lib/clang/{}/share".format(major_llvm_version),
+        toolchain_path_prefix + "lib64/clang/{}/include".format(major_llvm_version),
+    ]
 
     sysroot_path = compiler_configuration["sysroot_path"]
     sysroot_prefix = ""
@@ -370,4 +373,11 @@ def cc_toolchain_config(
         coverage_link_flags = coverage_link_flags,
         supports_start_end_lib = supports_start_end_lib,
         builtin_sysroot = sysroot_path,
+    )
+
+    system_module_map(
+        name = name + "-module",
+        toolchain = all_files,
+        cxx_builtin_include_directories = cxx_builtin_include_directories,
+        sysroot_path = sysroot_path,
     )

--- a/toolchain/internal/BUILD.bazel
+++ b/toolchain/internal/BUILD.bazel
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+exports_files(["generate_system_module_map.sh"])

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -299,6 +299,52 @@ def _cc_toolchain_str(
     # them into `dict`s.
     host_tools_info = json.decode(json.encode(host_tools_info))
 
+    # C++ built-in include directories.
+    # This contains both the includes shipped with the compiler as well as the sysroot (or host)
+    # include directories. While Bazel's default undeclared inclusions check does not seem to be
+    # triggered by header files under the execroot, we still include those paths here as they are
+    # visible via the "built_in_include_directories" attribute of CcToolchainInfo as well as to keep
+    # them in sync with the directories included in the system module map generated for the stricter
+    # "layering_check" feature.
+    toolchain_path_prefix = toolchain_info.llvm_dist_path_prefix
+    llvm_version = toolchain_info.llvm_version
+    major_llvm_version = int(llvm_version.split(".")[0])
+    target_system_name = {
+        "darwin-x86_64": "x86_64-apple-macosx",
+        "darwin-aarch64": "aarch64-apple-macosx",
+        "linux-aarch64": "aarch64-unknown-linux-gnu",
+        "linux-x86_64": "x86_64-unknown-linux-gnu",
+    }[target_pair]
+    cxx_builtin_include_directories = [
+        toolchain_path_prefix + "include/c++/v1",
+        toolchain_path_prefix + "include/{}/c++/v1".format(target_system_name),
+        toolchain_path_prefix + "lib/clang/{}/include".format(llvm_version),
+        toolchain_path_prefix + "lib/clang/{}/share".format(llvm_version),
+        toolchain_path_prefix + "lib64/clang/{}/include".format(llvm_version),
+        toolchain_path_prefix + "lib/clang/{}/include".format(major_llvm_version),
+        toolchain_path_prefix + "lib/clang/{}/share".format(major_llvm_version),
+        toolchain_path_prefix + "lib64/clang/{}/include".format(major_llvm_version),
+    ]
+
+    sysroot_prefix = ""
+    if sysroot_path:
+        sysroot_prefix = "%sysroot%"
+    if target_os == "linux":
+        cxx_builtin_include_directories.extend([
+            sysroot_prefix + "/include",
+            sysroot_prefix + "/usr/include",
+            sysroot_prefix + "/usr/local/include",
+        ])
+    elif target_os == "darwin":
+        cxx_builtin_include_directories.extend([
+            sysroot_prefix + "/usr/include",
+            sysroot_prefix + "/System/Library/Frameworks",
+        ])
+    else:
+        fail("Unreachable")
+
+    cxx_builtin_include_directories.extend(toolchain_info.additional_include_dirs_dict.get(target_pair, []))
+
     template = """
 # CC toolchain for cc-clang-{suffix}.
 
@@ -308,11 +354,11 @@ cc_toolchain_config(
     host_os = "{host_os}",
     target_arch = "{target_arch}",
     target_os = "{target_os}",
+    target_system_name = "{target_system_name}",
     toolchain_path_prefix = "{llvm_dist_path_prefix}",
     tools_path_prefix = "{tools_path_prefix}",
     wrapper_bin_prefix = "{wrapper_bin_prefix}",
     compiler_configuration = {{
-      "additional_include_dirs": {additional_include_dirs},
       "sysroot_path": "{sysroot_path}",
       "stdlib": "{stdlib}",
       "cxx_standard": "{cxx_standard}",
@@ -327,8 +373,8 @@ cc_toolchain_config(
       "coverage_link_flags": {coverage_link_flags},
       "unfiltered_compile_flags": {unfiltered_compile_flags},
     }},
-    llvm_version = "{llvm_version}",
     host_tools_info = {host_tools_info},
+    cxx_builtin_include_directories = {cxx_builtin_include_directories},
 )
 
 toolchain(
@@ -436,8 +482,8 @@ filegroup(
 system_module_map(
     name = "module-{suffix}",
     cxx_builtin_include_files = ":include-components-{suffix}",
-    cxx_builtin_include_directories = cxx_builtin_include_directories,
-    sysroot_path = %{sysroot_path},
+    cxx_builtin_include_directories = {cxx_builtin_include_directories},
+    sysroot_path = "{sysroot_path}",
 )
 
 cc_toolchain(
@@ -463,6 +509,7 @@ cc_toolchain(
         host_arch = host_arch,
         target_settings = _list_to_string(_dict_value(toolchain_info.target_settings_dict, target_pair)),
         target_os_bzl = target_os_bzl,
+        target_system_name = target_system_name,
         host_os_bzl = host_os_bzl,
         llvm_dist_label_prefix = toolchain_info.llvm_dist_label_prefix,
         llvm_dist_path_prefix = toolchain_info.llvm_dist_path_prefix,
@@ -470,7 +517,6 @@ cc_toolchain(
         wrapper_bin_prefix = toolchain_info.wrapper_bin_prefix,
         sysroot_label_str = sysroot_label_str,
         sysroot_path = sysroot_path,
-        additional_include_dirs = _list_to_string(toolchain_info.additional_include_dirs_dict.get(target_pair, [])),
         stdlib = _dict_value(toolchain_info.stdlib_dict, target_pair, "builtin-libc++"),
         cxx_standard = _dict_value(toolchain_info.cxx_standard_dict, target_pair, "c++17"),
         compile_flags = _list_to_string(_dict_value(toolchain_info.compile_flags_dict, target_pair)),
@@ -483,9 +529,9 @@ cc_toolchain(
         coverage_compile_flags = _list_to_string(_dict_value(toolchain_info.coverage_compile_flags_dict, target_pair)),
         coverage_link_flags = _list_to_string(_dict_value(toolchain_info.coverage_link_flags_dict, target_pair)),
         unfiltered_compile_flags = _list_to_string(_dict_value(toolchain_info.unfiltered_compile_flags_dict, target_pair)),
-        llvm_version = toolchain_info.llvm_version,
         extra_files_str = extra_files_str,
         host_tools_info = host_tools_info,
+        cxx_builtin_include_directories = _list_to_string(cxx_builtin_include_directories),
     )
 
 def _convenience_targets_str(rctx, use_absolute_paths, llvm_dist_rel_path, llvm_dist_label_prefix, host_dl_ext):

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -329,7 +329,6 @@ cc_toolchain_config(
     }},
     llvm_version = "{llvm_version}",
     host_tools_info = {host_tools_info},
-    all_files = "all-files-{suffix}",
 )
 
 toolchain(
@@ -426,6 +425,21 @@ filegroup(name = "strip-files-{suffix}", srcs = ["{llvm_dist_label_prefix}strip"
 """
 
     template = template + """
+filegroup(
+    name = "include-components-{suffix}",
+    srcs = [
+        ":compiler-components-{suffix}",
+        ":sysroot-components-{suffix}",
+    ],
+)
+
+system_module_map(
+    name = "module-{suffix}",
+    cxx_builtin_include_files = ":include-components-{suffix}",
+    cxx_builtin_include_directories = cxx_builtin_include_directories,
+    sysroot_path = %{sysroot_path},
+)
+
 cc_toolchain(
     name = "cc-clang-{suffix}",
     all_files = "all-files-{suffix}",
@@ -437,7 +451,7 @@ cc_toolchain(
     objcopy_files = "objcopy-files-{suffix}",
     strip_files = "strip-files-{suffix}",
     toolchain_config = "local-{suffix}",
-    module_map = "local-{suffix}-module",
+    module_map = "module-{suffix}",
 )
 """
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -329,6 +329,7 @@ cc_toolchain_config(
     }},
     llvm_version = "{llvm_version}",
     host_tools_info = {host_tools_info},
+    all_files = "all-files-{suffix}",
 )
 
 toolchain(
@@ -436,6 +437,7 @@ cc_toolchain(
     objcopy_files = "objcopy-files-{suffix}",
     strip_files = "strip-files-{suffix}",
     toolchain_config = "local-{suffix}",
+    module_map = "local-{suffix}-module",
 )
 """
 

--- a/toolchain/internal/generate_system_module_map.sh
+++ b/toolchain/internal/generate_system_module_map.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Based on:
+# https://github.com/bazelbuild/bazel/blob/44c5a1bbb26d3c61b37529b38406f1f5b0832baf/tools/cpp/generate_system_module_map.sh
+#
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+echo 'module "crosstool" [system] {'
+
+for dir in "$@"; do
+  find -L "${dir}" -type f 2>/dev/null | LANG=C sort | uniq | while read -r header; do
+    case "${dir}" in
+    /*) ;;
+    *) header=${EXECROOT_PREFIX}"${header}" ;;
+    esac
+    echo "  textual header \"${header}\""
+  done
+done
+
+echo "}"

--- a/toolchain/internal/generate_system_module_map.sh
+++ b/toolchain/internal/generate_system_module_map.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -eu
 
 echo 'module "crosstool" [system] {'
 
@@ -26,6 +26,8 @@ for dir in "$@"; do
     /*) ;;
     *) header="${EXECROOT_PREFIX}${header}" ;;
     esac
+    # The module map is expected to contain all possibly transitively included headers, including
+    # those provided by the sysroot or the host machine.
     echo "  textual header \"${header}\""
   done
 done

--- a/toolchain/internal/generate_system_module_map.sh
+++ b/toolchain/internal/generate_system_module_map.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
 
 echo 'module "crosstool" [system] {'
 
@@ -24,7 +24,7 @@ for dir in "$@"; do
   find -L "${dir}" -type f 2>/dev/null | LANG=C sort | uniq | while read -r header; do
     case "${dir}" in
     /*) ;;
-    *) header=${EXECROOT_PREFIX}"${header}" ;;
+    *) header="${EXECROOT_PREFIX}${header}" ;;
     esac
     echo "  textual header \"${header}\""
   done

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -1,0 +1,75 @@
+# Copyright 2024 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _system_module_map(ctx):
+    module_map = ctx.actions.declare_file(ctx.attr.name + ".modulemap")
+
+    # The builtin include directories are relative to the execroot, but the
+    # paths in the module map must be relative to the directory that contains
+    # the module map.
+    to_execroot = (module_map.dirname.count("/") + 1) * "../"
+
+    dirs = []
+    non_hermetic = False
+    for dir in ctx.attr.cxx_builtin_include_directories:
+        if ctx.attr.sysroot_path and dir.startswith("%sysroot%"):
+            dir = ctx.attr.sysroot_path + dir[len("%sysroot%"):]
+        if dir.startswith("/"):
+            non_hermetic = True
+        else:
+            dir = to_execroot + dir
+        dir = dir.replace("//", "/")
+        dirs.append(dir)
+
+    # If the action references a file outside of the execroot, it isn't safe to
+    # cache or run remotely.
+    execution_requirements = {}
+    if non_hermetic:
+        execution_requirements = {
+            "no-cache": "",
+            "no-remote": "",
+        }
+
+    ctx.actions.run_shell(
+        outputs = [module_map],
+        inputs = ctx.attr.toolchain[DefaultInfo].files,
+        arguments = [
+            ctx.executable._generate_system_module_map.path,
+            module_map.path,
+        ] + dirs,
+        tools = [ctx.executable._generate_system_module_map],
+        command = """
+"$1" "${@:3}" > "$2"
+""",
+        execution_requirements = execution_requirements,
+        mnemonic = "LlvmSystemModuleMap",
+        progress_message = "Generating system module map",
+    )
+    return DefaultInfo(files = depset([module_map]))
+
+system_module_map = rule(
+    doc = """Generates a Clang module map for the toolchain and sysroot headers.""",
+    implementation = _system_module_map,
+    attrs = {
+        "toolchain": attr.label(mandatory = True),
+        "cxx_builtin_include_directories": attr.string_list(mandatory = True),
+        "sysroot_path": attr.string(),
+        "_generate_system_module_map": attr.label(
+            default = "@bazel_tools//tools/cpp:generate_system_module_map.sh",
+            allow_single_file = True,
+            cfg = "exec",
+            executable = True,
+        ),
+    },
+)

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -52,7 +52,7 @@ def _system_module_map(ctx):
         tools = [ctx.executable._generate_system_module_map],
         env = {"EXECROOT_PREFIX": execroot_prefix},
         execution_requirements = execution_requirements,
-        mnemonic = "LlvmSystemModuleMap",
+        mnemonic = "LLVMSystemModuleMap",
         progress_message = "Generating system module map",
     )
     return DefaultInfo(files = depset([module_map]))


### PR DESCRIPTION
The general support for this feature is inherited from the Bazel-provided Unix C++ toolchain, except that a module map for the toolchain and sysroot headers has to be supplied to the `cc_toolchain`.

This requires updates of rules_go, abseil-cpp and openssl BUILD file changes to become compatible with the stricter checks. Also fixes CI issues caused by the release of Bazel 7.0.0.

Fixes #203