### PR TITLE
[WIP] Use llvm-libtool-darwin instead of llvm-ar (rebased)

### DIFF
--- a/.github/workflows/release_notes_template.txt
+++ b/.github/workflows/release_notes_template.txt
@@ -59,13 +59,4 @@ And add the following section to your .bazelrc file:
 ```sh
 # Not needed after https://github.com/bazelbuild/bazel/issues/7260 is closed
 build --incompatible_enable_cc_toolchain_resolution
-
-# For macOS only:
-
-# Needed for Bazel versions before 7.
-# Without this, one can use `--linkopt='-undefined dynamic_lookup'`.
-# This feature is intentionally not supported on macOS.
-build --features=-supports_dynamic_linker
-# Not needed after https://github.com/grailbio/bazel-toolchain/pull/229.
-build --features=-libtool
 ```

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,2 +1,1 @@
 build --incompatible_enable_cc_toolchain_resolution
-build --features=layering_check

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -263,7 +263,7 @@ def cc_toolchain_config(
     # The tool names come from [here](https://github.com/bazelbuild/bazel/blob/c7e58e6ce0a78fdaff2d716b4864a5ace8917626/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java#L76-L90):
     # NOTE: Ensure these are listed in toolchain_tools in toolchain/internal/common.bzl.
     tool_paths = {
-        "ar": tools_path_prefix + "llvm-ar",
+        "ar": tools_path_prefix + ("llvm-ar" if host_os != "darwin" else "llvm-libtool-darwin"),
         "cpp": tools_path_prefix + "clang-cpp",
         "dwp": tools_path_prefix + "llvm-dwp",
         "gcc": wrapper_bin_prefix + "cc_wrapper.sh",

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -14,7 +14,7 @@
 
 SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "aarch64")]
 
-toolchain_tools = [
+_toolchain_tools = [
     "clang-cpp",
     "ld.lld",
     "llvm-ar",
@@ -25,6 +25,10 @@ toolchain_tools = [
     "llvm-objcopy",
     "llvm-objdump",
     "llvm-strip",
+]
+
+_toolchain_tools_darwin = [
+    "llvm-libtool-darwin",
 ]
 
 def host_os_key(rctx):
@@ -175,6 +179,12 @@ def attr_dict(attr):
         tuples.append((key, val))
 
     return dict(tuples)
+
+def toolchain_tools(os):
+    tools = list(_toolchain_tools)
+    if os == "darwin":
+        tools.extend(_toolchain_tools_darwin)
+    return tools
 
 def _get_host_tool_info(rctx, tool_path, tool_key = None):
     if tool_key == None:

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -105,11 +105,12 @@ def llvm_register_toolchains():
         # symlinked path from the wrapper.
         wrapper_bin_prefix = "bin/"
         tools_path_prefix = "bin/"
-        for tool_name in _toolchain_tools:
+        tools = _toolchain_tools(os)
+        for tool_name in tools:
             rctx.symlink(llvm_dist_rel_path + "bin/" + tool_name, tools_path_prefix + tool_name)
         symlinked_tools_str = "".join([
-            "\n" + (" " * 8) + "\"" + tools_path_prefix + name + "\","
-            for name in _toolchain_tools
+            "\n" + (" " * 8) + "\"" + tools_path_prefix + tool_name + "\","
+            for tool_name in tools
         ])
     else:
         llvm_dist_rel_path = llvm_dist_path_prefix


### PR DESCRIPTION
This removes the need to provide `--features=-libtool` on macOS.

It looks like llvm-libtool-darwin is missing some flags, like `-s`.
```
llvm-libtool-darwin: Unknown command line argument '-s'.  Try: 'external/llvm_toolchain/bin/llvm-libtool-darwin --help'
```