### PR TITLE
Support response files with quoted args

### DIFF
--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -65,7 +65,9 @@ for ((i = 0; i <= $#; i++)); do
     while IFS= read -r line; do
       # Process every arg on the line individually.
       # Note that a single line can contain multiple args.
-      declare -a 'opts=('"$line"')'
+      # We also need to ensure args starting with $ are not expanded but passed as-is.
+      declare -a opts
+      mapfile -t opts < <(printf '%s' "$line" | xargs -n1)
       for opt in "${opts[@]}"; do
         opt="$(
           set -e

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -91,7 +91,9 @@ for ((i = 0; i <= $#; i++)); do
     while IFS= read -r line; do
       # Process every arg on the line individually.
       # Note that a single line can contain multiple args.
-      declare -a 'opts=('"$line"')'
+      # We also need to ensure args starting with $ are not expanded but passed as-is.
+      declare -a opts
+      mapfile -t opts < <(printf '%s' "$line" | xargs -n1)
       for opt in "${opts[@]}"; do
         if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
           cmd+=("-fuse-ld=lld")


### PR DESCRIPTION
https://github.com/bazel-contrib/toolchains_llvm/pull/245 introduced a regression where [clang response files](https://llvm.org/docs/CommandLine.html#response-files) were read and expanded into args on the command line.

This was a regression because response files support quoted args:

```
$ cat args
"-O3"
"main.cc"
$ clang @args  # success
```

but `cc_wrapper.sh` will expand this to 

```
$ clang '"-O3"' '"main.cc"'
clang: error: no such file or directory: '"-O3"'
clang: error: no such file or directory: '"main.cc"'
clang: error: no input files
```

This is not just a theoretical concern: golang (which is using a c++ linker for its cgo integration) is explicitly quoting its strings in the response files: https://github.com/golang/go/blob/ecc06f0db79193a4fe16138148c7eb26d9af96f1/src/cmd/link/internal/ld/lib.go#L2123-L2124

This PR solves this by processing what's inside the quotes instead of the string as a whole. As a bonus, this will also support multiple (quoted or unquoted) args on a single line, which is something clang supports but toolchains_llvm does not. The fix is inspired by https://stackoverflow.com/a/17346794 but modified to support args starting with `$` (need to be passed through).

Note that another related fix is https://github.com/bazel-contrib/toolchains_llvm/pull/430, which passes through the response files to clang. That PR would also be great to support very long arg lists, but we still need this PR to properly call `sanitize_option` for quoted args.