### PR TITLE
Probe each toolchain bin for existence

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -121,7 +121,12 @@ def llvm_config_impl(rctx):
         # symlinked path from the wrapper.
         wrapper_bin_prefix = "bin/"
         tools_path_prefix = "bin/"
-        tools = _toolchain_tools(os)
+        # Probe each binary for existence
+        tools = {}
+        for tool in _toolchain_tools(os).items():
+            if rctx.path(llvm_dist_rel_path + "bin/" + tool[0]).exists:
+                tools.update([tool])
+
         for tool_name, symlink_name in tools.items():
             rctx.symlink(llvm_dist_rel_path + "bin/" + tool_name, tools_path_prefix + symlink_name)
         symlinked_tools_str = "".join([


### PR DESCRIPTION
Probe each toolchain binary for existence before attempting to make symlinks to them.

This allows for llvm packages without tools that aren't needed by a given project.

A simple loop here was used for readability with consideration for the limited number of items in the loop.

Here is an example copy of `tools` after the filtering when using this package: https://github.com/MaterializeInc/toolchains/releases/tag/clang-18.1.8-5

```
 {"clang-cpp": "clang-cpp", "ld.lld": "ld.lld", "llvm-ar": "llvm-ar", "llvm-dwp": "llvm-dwp", "llvm-profdata": "llvm-profdata", "llvm-cov": "llvm-cov", "llvm-nm": "llvm-nm", "llvm-objcopy": "llvm-objcopy", "llvm-objdump": "llvm-objdump", "llvm-strip": "llvm-strip"}
```