### PR TITLE
Add support for riscv32-unknown-none-elf targets

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -97,6 +97,14 @@ def cc_toolchain_config(
             "clang",
             "glibc_unknown",
         ),
+        "none-riscv32": (
+            "clang-riscv32-none",
+            "riscv32",
+            "unknown",
+            "clang",
+            "unknown",
+            "unknown",
+        ),
         "none-x86_64": (
             "clang-x86_64-none",
             "k8",

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -18,6 +18,7 @@ SUPPORTED_TARGETS = [
     ("linux", "armv7"),
     ("darwin", "x86_64"),
     ("darwin", "aarch64"),
+    ("none", "riscv32"),
     ("none", "wasm32"),
     ("none", "wasm64"),
     ("none", "x86_64"),
@@ -27,6 +28,7 @@ SUPPORTED_TARGETS = [
 
 # These are targets that can build without a sysroot.
 SUPPORTED_NO_SYSROOT_TARGETS = [
+    ("none", "riscv32"),
     ("none", "x86_64"),
 ]
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -306,7 +306,7 @@ def _cc_toolchain_str(
         if exec_os == target_os and exec_arch == target_arch:
             # For darwin -> darwin, we can use the macOS SDK path.
             sysroot_path = _default_sysroot_path(rctx, exec_os)
-        elif target_pair in _supported_no_sysroot_targets:
+        elif (target_os, target_arch) in _supported_no_sysroot_targets:
             sysroot_path = ""
         else:
             # We are trying to cross-compile without a sysroot, let's bail.
@@ -331,6 +331,7 @@ def _cc_toolchain_str(
         "linux-aarch64": "aarch64-unknown-linux-gnu",
         "linux-armv7": "armv7-unknown-linux-gnueabihf",
         "linux-x86_64": "x86_64-unknown-linux-gnu",
+        "none-riscv32": "riscv32-unknown-none-elf",
         "none-x86_64": "x86_64-unknown-none",
         "wasm32": "wasm32-unknown-unknown",
         "wasm64": "wasm64-unknown-unknown",


### PR DESCRIPTION
This adds support for bare metal riscv32 targets that don't need a sysroot.

I have an esp32 riscv board that I'm building for, and to set up an appropriate toolchain, `toolchains_llvm` needs to know about it.
