### PR TITLE
[wrapper] Make `cc_wrapper.sh` POSIX-compliant and use `#!/bin/sh`

### DIFF
--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -35,6 +35,7 @@ filegroup(
     name = "internal-use-wrapped-tools",
     srcs = [
         "%{wrapper_bin_prefix}cc_wrapper.sh",
+        "%{wrapper_bin_prefix}cc_wrapper_inner.sh",
     ],
     visibility = ["//visibility:private"],
 )

--- a/toolchain/cc_wrapper_inner.sh.tpl
+++ b/toolchain/cc_wrapper_inner.sh.tpl
@@ -1,0 +1,148 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1083
+
+set -euo pipefail
+
+CLEANUP_FILES=()
+
+function cleanup() {
+  if [[ ${#CLEANUP_FILES[@]} -gt 0 ]]; then
+    rm -f "${CLEANUP_FILES[@]}"
+  fi
+}
+
+trap cleanup EXIT
+
+# See note in toolchain/internal/configure.bzl where we define
+# `wrapper_bin_prefix` for why this wrapper is needed.
+
+# this script is located at either
+# - <execroot>/external/<repo_name>/bin/cc_wrapper_innerr.sh
+# - <runfiles>/<repo_name>/bin/cc_wrapper_inner.sh
+# The clang is located at
+# - <execroot>/external/<repo_name2>/bin/clang
+# - <runfiles>/<repo_name2>/bin/clang
+#
+# In both cases, getting to clang can be done via
+# Finding the current dir of this script,
+# - <execroot>/external/<repo_name>/bin/
+# - <runfiles>/<repo_name>/bin/
+# going back 2 directories
+# - <execroot>/external
+# - <runfiles>
+#
+# Going into %{toolchain_path_prefix} without the `external/` prefix + `bin/clang`
+#
+
+dirname_shim() {
+  local path="$1"
+
+  # Remove trailing slashes
+  path="${path%/}"
+
+  # If there's no slash, return "."
+  if [[ "${path}" != */* ]]; then
+    echo "."
+    return
+  fi
+
+  # Remove the last component after the final slash
+  path="${path%/*}"
+
+  # If it becomes empty, it means root "/"
+  echo "${path:-/}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  bash_source_abs="$(realpath "${BASH_SOURCE[0]}")"
+  pwd_abs="$(realpath ".")"
+  bash_source_rel=${bash_source_abs#"${pwd_abs}/"}
+else
+  bash_source_rel="${BASH_SOURCE[0]}"
+fi
+script_dir=$(dirname_shim "${bash_source_rel}")
+toolchain_path_prefix="%{toolchain_path_prefix}"
+
+# Sometimes this path may be an absolute path in which case we dont do anything because
+# This is using the host toolchain to build.
+if [[ ${toolchain_path_prefix} != /* ]]; then
+  # shellcheck disable=SC2312
+  toolchain_path_prefix="$(dirname_shim "$(dirname_shim "${script_dir}")")/${toolchain_path_prefix#external/}"
+fi
+
+if [[ ! -f ${toolchain_path_prefix}bin/clang ]]; then
+  echo >&2 "ERROR: could not find clang; PWD=\"${PWD}\"; PATH=\"${PATH}\"; toolchain_path_prefix=${toolchain_path_prefix}."
+  exit 5
+fi
+
+OUTPUT=
+
+function parse_option() {
+  local -r opt="$1"
+  if [[ "${OUTPUT}" = "1" ]]; then
+    OUTPUT=${opt}
+  elif [[ "${opt}" = "-o" ]]; then
+    # output is coming
+    OUTPUT=1
+  fi
+}
+
+function sanitize_option() {
+  local -r opt=$1
+  if [[ ${opt} == */cc_wrapper.sh ]]; then
+    printf "%s" "${toolchain_path_prefix}bin/clang"
+  elif [[ ${opt} =~ ^-fsanitize-(ignore|black)list=[^/] ]] && [[ ${script_dir} == /* ]]; then
+    # shellcheck disable=SC2206
+    parts=(${opt/=/ }) # Split flag name and value into array.
+    # shellcheck disable=SC2312
+    printf "%s" "${parts[0]}=$(dirname_shim "$(dirname_shim "$(dirname_shim "${script_dir}")")")/${parts[1]}"
+  else
+    printf "%s" "${opt}"
+  fi
+}
+
+cmd=()
+for ((i = 0; i <= $#; i++)); do
+  if [[ ${!i} == @* && -r "${i:1}" ]]; then
+    # Create a new, sanitized file.
+    tmpfile=$(mktemp)
+    CLEANUP_FILES+=("${tmpfile}")
+    while IFS= read -r opt; do
+      opt="$(
+        set -e
+        sanitize_option "${opt}"
+      )"
+      parse_option "${opt}"
+      echo "${opt}" >>"${tmpfile}"
+    done <"${!i:1}"
+    cmd+=("@${tmpfile}")
+  else
+    opt="$(
+      set -e
+      sanitize_option "${!i}"
+    )"
+    parse_option "${opt}"
+    cmd+=("${opt}")
+  fi
+done
+
+# Call the C++ compiler.
+"${cmd[@]}"
+
+# Generate an empty file if header processing succeeded.
+if [[ "${OUTPUT}" == *.h.processed ]]; then
+  echo -n >"${OUTPUT}"
+fi

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -236,18 +236,36 @@ def llvm_config_impl(rctx):
         },
     )
 
-    # CC wrapper script; see comments near the definition of `wrapper_bin_prefix`.
-    if os == "darwin":
-        cc_wrapper_tpl = rctx.attr._darwin_cc_wrapper_sh_tpl
-    else:
-        cc_wrapper_tpl = rctx.attr._cc_wrapper_sh_tpl
+    # CC wrapper scripts; see comments near the definition of `wrapper_bin_prefix`.
     rctx.template(
         "bin/cc_wrapper.sh",
-        cc_wrapper_tpl,
+        rctx.attr._cc_wrapper_sh_tpl,
         {
             "%{toolchain_path_prefix}": llvm_dist_path_prefix,
         },
     )
+    if os == "darwin":
+        cc_wrapper_inner_tpl = rctx.attr._darwin_cc_wrapper_inner_sh_tpl
+    else:
+        cc_wrapper_inner_tpl = rctx.attr._cc_wrapper_inner_sh_tpl
+    rctx.template(
+        "bin/cc_wrapper_inner.sh",
+        cc_wrapper_inner_tpl,
+        {
+            "%{toolchain_path_prefix}": llvm_dist_path_prefix,
+        },
+    )
+
+    # Inner CC wrapper script (redirect used for shell compatibility on Linux
+    # platforms).
+    if os != "darwin":
+        rctx.template(
+            "bin/cc_wrapper_inner.sh",
+            rctx.attr._cc_wrapper_inner_sh_tpl,
+            {
+                "%{toolchain_path_prefix}": llvm_dist_path_prefix,
+            },
+        )
 
     if hasattr(rctx, "repo_metadata"):
         return rctx.repo_metadata(reproducible = True)

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -408,11 +408,14 @@ llvm_config_attrs.update({
     "_build_toolchain_tpl": attr.label(
         default = "//toolchain:BUILD.toolchain.tpl",
     ),
-    "_darwin_cc_wrapper_sh_tpl": attr.label(
-        default = "//toolchain:osx_cc_wrapper.sh.tpl",
-    ),
     "_cc_wrapper_sh_tpl": attr.label(
         default = "//toolchain:cc_wrapper.sh.tpl",
+    ),
+    "_darwin_cc_wrapper_inner_sh_tpl": attr.label(
+        default = "//toolchain:osx_cc_wrapper_inner.sh.tpl",
+    ),
+    "_cc_wrapper_inner_sh_tpl": attr.label(
+        default = "//toolchain:cc_wrapper_inner.sh.tpl",
     ),
 })
 

--- a/toolchain/osx_cc_wrapper_inner.sh.tpl
+++ b/toolchain/osx_cc_wrapper_inner.sh.tpl
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,8 +65,8 @@ function parse_option() {
 # `wrapper_bin_prefix` for why this wrapper is needed.
 
 # this script is located at either
-# - <execroot>/external/<repo_name>/bin/cc_wrapper.sh
-# - <runfiles>/<repo_name>/bin/cc_wrapper.sh
+# - <execroot>/external/<repo_name>/bin/cc_wrapper_inner.sh
+# - <runfiles>/<repo_name>/bin/cc_wrapper_inner.sh
 # The clang is located at
 # - <execroot>/external/<repo_name2>/bin/clang
 # - <runfiles>/<repo_name2>/bin/clang


### PR DESCRIPTION
Some Linux distributions, such as NixOS, do not provide `/bin/bash`. This PR aims to make the LLVM toolchain compatible with these platforms by only using POSIX-compatible features in the shell script and replacing the shebang with `#!/bin/sh`.

Prior to this change, attempting to use the LLVM toolchain to build a C/C++ target on NixOS causes an error like:

```src/main/tools/linux-sandbox-pid1.cc:548: "execvp(external/toolchains_llvm~~llvm~llvm_toolchain/bin/cc_wrapper.sh, 0x1ce8a310)": No such file or directory```

where the `No such file or directory` error is referring to `/bin/bash`, not the `cc_wrapper.sh` script itself. In fact, trying to run `bazel-REPONAME/external/toolchains_llvm~~llvm~llvm_toolchain/bin/cc_wrapper.sh` manually afterwards gives a `Required file not found` error.

This PR emerged out of a discussion on #543, where it was noticed that replacing the `#!/bin/bash` shebang with `#!/usr/bin/env bash` causes issues when the calling rule does not include `/usr/bin` in `PATH` (`rules_rust` hits this case).

This PR does not update the corresponding MacOS script, as all MacOS platforms should have `/bin/bash`. 

Supercedes #543.