### PR TITLE
toolchain: Add compiler-rt symbol files for sanitizers

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -73,6 +73,7 @@ filegroup(
             "lib/**/lib*.a",
             "lib/clang/*/lib/**/*.a",
             "lib/clang/*/lib/**/*.dylib",
+            "lib/clang/*/lib/**/*.syms",
             # clang_rt.*.o supply crtbegin and crtend sections.
             "lib/**/clang_rt.*.o",
         ],


### PR DESCRIPTION
it seems these .syms files control symbol exports for sanitizer builds

without this im seeing 20% increase in instrumented binary size, and 150x more exported symbols - it also _might_ be contributing to some tsan test issues im facing switching to the hermetic toolchain