### PR TITLE
toolchain: Set `link_libs` rather than `link_flags`

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -276,7 +276,7 @@ def cc_toolchain_config(
         else:
             # For single-platform builds, we can statically link the bundled
             # libraries.
-            link_flags.extend([
+            link_libs.extend([
                 "-l:libc++.a",
                 "-l:libc++abi.a",
             ])
@@ -294,7 +294,7 @@ def cc_toolchain_config(
             "-stdlib=libc++",
         ]
 
-        link_flags.extend([
+        link_libs.extend([
             "-l:libc++.a",
             "-l:libc++abi.a",
         ])


### PR DESCRIPTION
without this our TSAN/MSAN CI fails as it clobbers our setup to use the instrumented stdlib