### PR TITLE
[bugfix] Reference os variable instead of os function

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -118,7 +118,7 @@ def host_info(rctx):
     if _os == "linux" and not rctx.attr.exec_os:
         dist_name, dist_version = _linux_dist(rctx)
     else:
-        dist_name = os
+        dist_name = _os
         dist_version = ""
     return struct(
         arch = _arch,


### PR DESCRIPTION
on toolchain/internal/common.bzl:121, we referenced the `os` function instead of the local `_os` variable, which made my local build throw stacktraces on toolchain_llvm v1.5.0 (was ok in v1.4.0).

I no longer have stacktraces with this fix locally present..