### PR TITLE
fix: Set allow_empty on lib filegroup

### DIFF
--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -91,7 +91,7 @@ filegroup(
     ] + glob([
         "lib/**/libc++*.a",
         "lib/**/libunwind.a",
-    ]),
+    ], allow_empty = True),
 )
 
 filegroup(


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/bazel-contrib/toolchains_llvm/pull/580:

```
ERROR: Traceback (most recent call last):
	File "/tmp/containerbase/cache/.cache/bazel/_bazel_ubuntu/584cba79b2819b2d6448a0fcd59d73a4/external/toolchains_llvm++llvm+llvm_toolchain_linux_exec_llvm/BUILD.bazel", line 91, column 13, in <toplevel>
		] + glob([
Error in glob: glob pattern 'lib/**/libc++*.a' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
```