### PR TITLE
fix: Set allow_empty on lib_legacy filegroup

### DIFF
--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -103,7 +103,7 @@ filegroup(
         "lib/clang/{LLVM_VERSION}/lib/**",
         "lib/**/libc++*.a",
         "lib/**/libunwind.a",
-    ]),
+    ], allow_empty = True),
 )
 
 filegroup(


### PR DESCRIPTION
`lib_legacy` needs the same treatment `lib` got in https://github.com/bazel-contrib/toolchains_llvm/pull/635