### PR TITLE
fix crash when version_or_requirements is None

### DIFF
--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1167,7 +1167,9 @@ def _find_llvm_basename_or_error(llvm_version, all_llvm_distributions, host_info
 
 def _is_requirement(version_or_requirements):
     """Return whether `version_or_requirements` is likely a requirement (True) or should be a version."""
-    if version_or_requirements and version_or_requirements.startswith("getenv("):
+    if not version_or_requirements:
+        return False
+    if version_or_requirements.startswith("getenv("):
         return True
     for prefix in ["first:", "latest:"]:
         if version_or_requirements.startswith(prefix) or version_or_requirements == prefix[:-1]:


### PR DESCRIPTION
If `exec_os_arch_dict_value` hits its default value (None) when called by `required_llvm_version_rctx`, it will cause a crash loading toolchains_llvm (see below). This PR fixes this crash by checking if the field is None before accessing a method on it.

```python
ERROR: /<snip>/external/toolchains_llvm+/toolchain/internal/llvm_distributions.bzl:1170:31: An error occurred during the fetch of repository 'toolchains_llvm++llvm+llvm_toolchain':
   Traceback (most recent call last):
	File "/<snip>/external/toolchains_llvm+/toolchain/internal/configure.bzl", line 87, column 47, in llvm_config_impl
		llvm_version = _required_llvm_version_rctx(rctx)
	File "/<snip>/external/toolchains_llvm+/toolchain/internal/llvm_distributions.bzl", line 1259, column 23, in required_llvm_version_rctx
		if _is_requirement(llvm_version):
	File "/<snip>/external/toolchains_llvm+/toolchain/internal/llvm_distributions.bzl", line 1170, column 31, in _is_requirement
		if version_or_requirements.startswith("getenv("):
Error: 'NoneType' value has no field or method 'startswith'
```