### PR TITLE
Load toolchains_llvm dependencies earlier in tests

### DIFF
--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -19,6 +19,10 @@ local_repository(
     path = "..",
 )
 
+load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -49,10 +53,6 @@ http_archive(
 load("@tar.bzl//tar:extensions.bzl", "create_repositories")
 
 create_repositories()
-
-load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
-
-bazel_toolchain_dependencies()
 
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 


### PR DESCRIPTION
There are certain dependency requirements for toolchains_llvm. Without Bzlmod, the user must take care that are correct or call the macro to load transitive dependencies.
If this is done in a too late step, a version of a transitive dependency might be taken instead of the one that toolchains_llvm require.
This commit move the load at the beginning to mimic what the user should do without Bzlmod.
With this change, the version of skylib defined in toolchains_llvm is taken instead of the one defined in bazel_features repository.