### PR TITLE
Fix LLVM binary resolution for unrecognized Linux distros

### DIFF
--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1100,7 +1100,7 @@ def _find_llvm_basename_list(llvm_version, all_llvm_distributions, host_info):
                 "sparc64": ["sparc64", "sparcv9"],
                 "sparcv9": ["sparcv9", "sparc64"],
             }.get(arch, [arch])
-            os_name_list = _dist_to_os_names(dist)
+            os_name_list = _dist_to_os_names(dist, ["linux-gnu", "unknown-linux-gnu"])
             os_name_extra_list = []
             if _is_linux_dist(dist) and [os for os in os_name_list if "linux" in os]:
                 os_name_extra_list = ["linux-gnu", "unknown-linux-gnu"]
@@ -1139,7 +1139,7 @@ def _find_llvm_basename_list(llvm_version, all_llvm_distributions, host_info):
         }.get(arch, [arch])
 
         prefixes = []
-        for dist_name in _dist_to_os_names(dist, [dist.name]):
+        for dist_name in _dist_to_os_names(dist, ["linux-gnu", "unknown-linux-gnu"]):
             for arch_alias in arch_alias_list:
                 basenames = _find_llvm_basenames_by_stem(
                     prefixes = [
@@ -1450,6 +1450,7 @@ def _distributions_test_writer_impl(ctx):
             struct(name = "ubuntu", version = "20.10"),
             struct(name = "ubuntu", version = "22.04"),
             struct(name = "ubuntu", version = "24.04"),
+            struct(name = "void", version = ANY_VERSION),
             struct(name = "wolfi", version = ANY_VERSION),
         ],
     }

--- a/toolchain/internal/llvm_distributions.golden.sel.txt
+++ b/toolchain/internal/llvm_distributions.golden.sel.txt
@@ -35,6 +35,7 @@
 6.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-6.0.0-aarch64-linux-gnu.tar.xz
 6.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-6.0.0-aarch64-linux-gnu.tar.xz
 6.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-6.0.0-aarch64-linux-gnu.tar.xz
+6.0.0-aarch64-linux/void/0 -> clang+llvm-6.0.0-aarch64-linux-gnu.tar.xz
 6.0.0-aarch64-linux/wolfi/0 -> clang+llvm-6.0.0-aarch64-linux-gnu.tar.xz
 6.0.0-armv7a-linux/arch/0 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
 6.0.0-armv7a-linux/centos/6 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -59,6 +60,7 @@
 6.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
 6.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
 6.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
+6.0.0-armv7a-linux/void/0 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
 6.0.0-armv7a-linux/wolfi/0 -> clang+llvm-6.0.0-armv7a-linux-gnueabihf.tar.xz
 6.0.0-mips-linux/amzn/0 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
 6.0.0-mips-linux/arch/0 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
@@ -91,6 +93,7 @@
 6.0.0-mips-linux/ubuntu/20.10 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
 6.0.0-mips-linux/ubuntu/22.04 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
 6.0.0-mips-linux/ubuntu/24.04 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
+6.0.0-mips-linux/void/0 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
 6.0.0-mips-linux/wolfi/0 -> clang+llvm-6.0.0-mips-linux-gnu.tar.xz
 6.0.0-mipsel-linux/amzn/0 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
 6.0.0-mipsel-linux/arch/0 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
@@ -123,6 +126,7 @@
 6.0.0-mipsel-linux/ubuntu/20.10 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
 6.0.0-mipsel-linux/ubuntu/22.04 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
 6.0.0-mipsel-linux/ubuntu/24.04 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
+6.0.0-mipsel-linux/void/0 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
 6.0.0-mipsel-linux/wolfi/0 -> clang+llvm-6.0.0-mipsel-linux-gnu.tar.xz
 6.0.0-x86_32-linux/arch/0 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
 6.0.0-x86_32-linux/centos/6 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
@@ -147,6 +151,7 @@
 6.0.0-x86_32-linux/ubuntu/20.10 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
 6.0.0-x86_32-linux/ubuntu/22.04 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
 6.0.0-x86_32-linux/ubuntu/24.04 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
+6.0.0-x86_32-linux/void/0 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
 6.0.0-x86_32-linux/wolfi/0 -> clang+llvm-6.0.0-i686-linux-gnu-Fedora27.tar.xz
 6.0.0-x86_64-darwin/darwin/ -> clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
 6.0.0-x86_64-linux/amzn/0 -> clang+llvm-6.0.0-x86_64-linux-sles12.2.tar.xz
@@ -180,6 +185,7 @@
 6.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 6.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 6.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+6.0.0-x86_64-linux/void/0 -> clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27.tar.xz
 6.0.0-x86_64-linux/wolfi/0 -> clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 6.0.1-x86_32-linux/freebsd/10 -> clang+llvm-6.0.1-i386-unknown-freebsd10.tar.xz
 6.0.1-x86_64-linux/amzn/0 -> clang+llvm-6.0.1-x86_64-linux-sles12.3.tar.xz
@@ -213,6 +219,7 @@
 6.0.1-x86_64-linux/ubuntu/20.10 -> clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 6.0.1-x86_64-linux/ubuntu/22.04 -> clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 6.0.1-x86_64-linux/ubuntu/24.04 -> clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+6.0.1-x86_64-linux/void/0 -> clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 6.0.1-x86_64-linux/wolfi/0 -> clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 7.0.0-x86_32-linux/freebsd/10 -> clang+llvm-7.0.0-i386-unknown-freebsd-10.tar.xz
 7.0.0-x86_64-darwin/darwin/ -> clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
@@ -247,6 +254,7 @@
 7.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 7.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 7.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+7.0.0-x86_64-linux/void/0 -> clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 7.0.0-x86_64-linux/wolfi/0 -> clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 8.0.0-aarch64-linux/amzn/0 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
 8.0.0-aarch64-linux/arch/0 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
@@ -279,6 +287,7 @@
 8.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
 8.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
 8.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
+8.0.0-aarch64-linux/void/0 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
 8.0.0-aarch64-linux/wolfi/0 -> clang+llvm-8.0.0-aarch64-linux-gnu.tar.xz
 8.0.0-armv7a-linux/arch/0 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
 8.0.0-armv7a-linux/centos/6 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -303,6 +312,7 @@
 8.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
 8.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
 8.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
+8.0.0-armv7a-linux/void/0 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
 8.0.0-armv7a-linux/wolfi/0 -> clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
 8.0.0-x86_32-linux/freebsd/11 -> clang+llvm-8.0.0-i386-unknown-freebsd11.tar.xz
 8.0.0-x86_64-darwin/darwin/ -> clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz
@@ -337,6 +347,7 @@
 8.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 8.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 8.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+8.0.0-x86_64-linux/void/0 -> clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 8.0.0-x86_64-linux/wolfi/0 -> clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 8.0.1-aarch64-linux/amzn/0 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
 8.0.1-aarch64-linux/arch/0 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
@@ -369,6 +380,7 @@
 8.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
 8.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
 8.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
+8.0.1-aarch64-linux/void/0 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
 8.0.1-aarch64-linux/wolfi/0 -> clang+llvm-8.0.1-aarch64-linux-gnu.tar.xz
 8.0.1-armv7a-linux/arch/0 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
 8.0.1-armv7a-linux/centos/6 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -393,6 +405,7 @@
 8.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
 8.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
 8.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
+8.0.1-armv7a-linux/void/0 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
 8.0.1-armv7a-linux/wolfi/0 -> clang+llvm-8.0.1-armv7a-linux-gnueabihf.tar.xz
 8.0.1-powerpc64le-linux/arch/0 -> clang+llvm-8.0.1-powerpc64le-linux-ubuntu-16.04.tar.xz
 8.0.1-powerpc64le-linux/chainguard/0 -> clang+llvm-8.0.1-powerpc64le-linux-ubuntu-16.04.tar.xz
@@ -447,6 +460,7 @@
 8.0.1-x86_64-linux/ubuntu/20.10 -> clang+llvm-8.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 8.0.1-x86_64-linux/ubuntu/22.04 -> clang+llvm-8.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 8.0.1-x86_64-linux/ubuntu/24.04 -> clang+llvm-8.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+8.0.1-x86_64-linux/void/0 -> clang+llvm-8.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 8.0.1-x86_64-linux/wolfi/0 -> clang+llvm-8.0.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 9.0.0-aarch64-linux/amzn/0 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
 9.0.0-aarch64-linux/arch/0 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
@@ -479,6 +493,7 @@
 9.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
 9.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
 9.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
+9.0.0-aarch64-linux/void/0 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
 9.0.0-aarch64-linux/wolfi/0 -> clang+llvm-9.0.0-aarch64-linux-gnu.tar.xz
 9.0.0-armv7a-linux/arch/0 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
 9.0.0-armv7a-linux/centos/6 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -503,6 +518,7 @@
 9.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
 9.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
 9.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
+9.0.0-armv7a-linux/void/0 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
 9.0.0-armv7a-linux/wolfi/0 -> clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
 9.0.0-powerpc64le-linux/arch/0 -> clang+llvm-9.0.0-powerpc64le-linux-ubuntu-16.04.tar.xz
 9.0.0-powerpc64le-linux/chainguard/0 -> clang+llvm-9.0.0-powerpc64le-linux-ubuntu-16.04.tar.xz
@@ -561,6 +577,7 @@
 9.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 9.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 9.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+9.0.0-x86_64-linux/void/0 -> clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 9.0.0-x86_64-linux/wolfi/0 -> clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 10.0.0-aarch64-linux/amzn/0 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
 10.0.0-aarch64-linux/arch/0 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
@@ -593,6 +610,7 @@
 10.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
 10.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
 10.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
+10.0.0-aarch64-linux/void/0 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
 10.0.0-aarch64-linux/wolfi/0 -> clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
 10.0.0-armv7a-linux/arch/0 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
 10.0.0-armv7a-linux/centos/6 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -617,6 +635,7 @@
 10.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
 10.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
 10.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
+10.0.0-armv7a-linux/void/0 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
 10.0.0-armv7a-linux/wolfi/0 -> clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz
 10.0.0-powerpc64le-linux/arch/0 -> clang+llvm-10.0.0-powerpc64le-linux-ubuntu-16.04.tar.xz
 10.0.0-powerpc64le-linux/chainguard/0 -> clang+llvm-10.0.0-powerpc64le-linux-ubuntu-16.04.tar.xz
@@ -675,6 +694,7 @@
 10.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 10.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 10.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+10.0.0-x86_64-linux/void/0 -> clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 10.0.0-x86_64-linux/wolfi/0 -> clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 10.0.1-aarch64-linux/amzn/0 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
 10.0.1-aarch64-linux/arch/0 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
@@ -707,6 +727,7 @@
 10.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
 10.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
 10.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
+10.0.1-aarch64-linux/void/0 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
 10.0.1-aarch64-linux/wolfi/0 -> clang+llvm-10.0.1-aarch64-linux-gnu.tar.xz
 10.0.1-armv7a-linux/arch/0 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
 10.0.1-armv7a-linux/centos/6 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -731,6 +752,7 @@
 10.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
 10.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
 10.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
+10.0.1-armv7a-linux/void/0 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
 10.0.1-armv7a-linux/wolfi/0 -> clang+llvm-10.0.1-armv7a-linux-gnueabihf.tar.xz
 10.0.1-powerpc64le-linux/arch/0 -> clang+llvm-10.0.1-powerpc64le-linux-ubuntu-16.04.tar.xz
 10.0.1-powerpc64le-linux/chainguard/0 -> clang+llvm-10.0.1-powerpc64le-linux-ubuntu-16.04.tar.xz
@@ -786,6 +808,7 @@
 10.0.1-x86_64-linux/ubuntu/20.10 -> clang+llvm-10.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 10.0.1-x86_64-linux/ubuntu/22.04 -> clang+llvm-10.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 10.0.1-x86_64-linux/ubuntu/24.04 -> clang+llvm-10.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+10.0.1-x86_64-linux/void/0 -> clang+llvm-10.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 10.0.1-x86_64-linux/wolfi/0 -> clang+llvm-10.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 11.0.0-sparc64-linux/sun-solaris/2.11 -> clang+llvm-11.0.0-sparcv9-sun-solaris2.11.tar.xz
 11.0.0-sparcv9-linux/sun-solaris/2.11 -> clang+llvm-11.0.0-sparcv9-sun-solaris2.11.tar.xz
@@ -821,6 +844,7 @@
 11.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 11.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 11.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
+11.0.0-x86_64-linux/void/0 -> clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 11.0.0-x86_64-linux/wolfi/0 -> clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 11.0.1-aarch64-linux/amzn/0 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
 11.0.1-aarch64-linux/arch/0 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
@@ -853,6 +877,7 @@
 11.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
 11.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
 11.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
+11.0.1-aarch64-linux/void/0 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
 11.0.1-aarch64-linux/wolfi/0 -> clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz
 11.0.1-armv7a-linux/arch/0 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
 11.0.1-armv7a-linux/centos/6 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -877,6 +902,7 @@
 11.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
 11.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
 11.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
+11.0.1-armv7a-linux/void/0 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
 11.0.1-armv7a-linux/wolfi/0 -> clang+llvm-11.0.1-armv7a-linux-gnueabihf.tar.xz
 11.0.1-powerpc64le-linux/arch/0 -> clang+llvm-11.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz
 11.0.1-powerpc64le-linux/chainguard/0 -> clang+llvm-11.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -933,6 +959,7 @@
 11.0.1-x86_64-linux/ubuntu/20.10 -> clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-20.10.tar.xz
 11.0.1-x86_64-linux/ubuntu/22.04 -> clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-20.10.tar.xz
 11.0.1-x86_64-linux/ubuntu/24.04 -> clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-20.10.tar.xz
+11.0.1-x86_64-linux/void/0 -> clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 11.0.1-x86_64-linux/wolfi/0 -> clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-20.10.tar.xz
 11.1.0-aarch64-linux/amzn/0 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
 11.1.0-aarch64-linux/arch/0 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
@@ -965,6 +992,7 @@
 11.1.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
 11.1.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
 11.1.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
+11.1.0-aarch64-linux/void/0 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
 11.1.0-aarch64-linux/wolfi/0 -> clang+llvm-11.1.0-aarch64-linux-gnu.tar.xz
 11.1.0-armv7a-linux/arch/0 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
 11.1.0-armv7a-linux/centos/6 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
@@ -989,6 +1017,7 @@
 11.1.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
 11.1.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
 11.1.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
+11.1.0-armv7a-linux/void/0 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
 11.1.0-armv7a-linux/wolfi/0 -> clang+llvm-11.1.0-armv7a-linux-gnueabihf.tar.xz
 11.1.0-powerpc64le-linux/arch/0 -> clang+llvm-11.1.0-powerpc64le-linux-ubuntu-18.04.tar.xz
 11.1.0-powerpc64le-linux/chainguard/0 -> clang+llvm-11.1.0-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -1045,6 +1074,7 @@
 11.1.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10.tar.xz
 11.1.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10.tar.xz
 11.1.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10.tar.xz
+11.1.0-x86_64-linux/void/0 -> clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 11.1.0-x86_64-linux/wolfi/0 -> clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10.tar.xz
 12.0.0-aarch64-linux/amzn/0 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
 12.0.0-aarch64-linux/arch/0 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
@@ -1077,6 +1107,7 @@
 12.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
 12.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
 12.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
+12.0.0-aarch64-linux/void/0 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
 12.0.0-aarch64-linux/wolfi/0 -> clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz
 12.0.0-armv7a-linux/arch/0 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
 12.0.0-armv7a-linux/centos/6 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -1101,6 +1132,7 @@
 12.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
 12.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
 12.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
+12.0.0-armv7a-linux/void/0 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
 12.0.0-armv7a-linux/wolfi/0 -> clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz
 12.0.0-x86_32-linux/freebsd/11 -> clang+llvm-12.0.0-i386-unknown-freebsd11.tar.xz
 12.0.0-x86_32-linux/freebsd/12 -> clang+llvm-12.0.0-i386-unknown-freebsd12.tar.xz
@@ -1137,6 +1169,7 @@
 12.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 12.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 12.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
+12.0.0-x86_64-linux/void/0 -> clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 12.0.0-x86_64-linux/wolfi/0 -> clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 12.0.1-aarch64-linux/amzn/0 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
 12.0.1-aarch64-linux/arch/0 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
@@ -1169,6 +1202,7 @@
 12.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
 12.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
 12.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
+12.0.1-aarch64-linux/void/0 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
 12.0.1-aarch64-linux/wolfi/0 -> clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz
 12.0.1-armv7a-linux/arch/0 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
 12.0.1-armv7a-linux/centos/6 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -1193,6 +1227,7 @@
 12.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
 12.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
 12.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
+12.0.1-armv7a-linux/void/0 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
 12.0.1-armv7a-linux/wolfi/0 -> clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz
 12.0.1-powerpc64le-linux/arch/0 -> clang+llvm-12.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz
 12.0.1-powerpc64le-linux/chainguard/0 -> clang+llvm-12.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -1249,6 +1284,7 @@
 12.0.1-x86_64-linux/ubuntu/20.10 -> clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 12.0.1-x86_64-linux/ubuntu/22.04 -> clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 12.0.1-x86_64-linux/ubuntu/24.04 -> clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+12.0.1-x86_64-linux/void/0 -> clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 12.0.1-x86_64-linux/wolfi/0 -> clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 13.0.0-powerpc64le-linux/arch/0 -> clang+llvm-13.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz
 13.0.0-powerpc64le-linux/chainguard/0 -> clang+llvm-13.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -1306,6 +1342,7 @@
 13.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 13.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 13.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
+13.0.0-x86_64-linux/void/0 -> clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 13.0.0-x86_64-linux/wolfi/0 -> clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
 13.0.1-aarch64-linux/amzn/0 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
 13.0.1-aarch64-linux/arch/0 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
@@ -1338,6 +1375,7 @@
 13.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
 13.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
 13.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
+13.0.1-aarch64-linux/void/0 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
 13.0.1-aarch64-linux/wolfi/0 -> clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz
 13.0.1-armv7a-linux/arch/0 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
 13.0.1-armv7a-linux/centos/6 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -1362,6 +1400,7 @@
 13.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
 13.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
 13.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
+13.0.1-armv7a-linux/void/0 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
 13.0.1-armv7a-linux/wolfi/0 -> clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz
 13.0.1-powerpc64le-linux/arch/0 -> clang+llvm-13.0.1-powerpc64le-linux-ubuntu-18.04.5.tar.xz
 13.0.1-powerpc64le-linux/chainguard/0 -> clang+llvm-13.0.1-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -1419,6 +1458,7 @@
 13.0.1-x86_64-linux/ubuntu/20.10 -> clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 13.0.1-x86_64-linux/ubuntu/22.04 -> clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 13.0.1-x86_64-linux/ubuntu/24.04 -> clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+13.0.1-x86_64-linux/void/0 -> clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 13.0.1-x86_64-linux/wolfi/0 -> clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 14.0.0-aarch64-linux/amzn/0 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
 14.0.0-aarch64-linux/arch/0 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
@@ -1451,6 +1491,7 @@
 14.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
 14.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
 14.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
+14.0.0-aarch64-linux/void/0 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
 14.0.0-aarch64-linux/wolfi/0 -> clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz
 14.0.0-armv7a-linux/arch/0 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
 14.0.0-armv7a-linux/centos/6 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -1475,6 +1516,7 @@
 14.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
 14.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
 14.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
+14.0.0-armv7a-linux/void/0 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
 14.0.0-armv7a-linux/wolfi/0 -> clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz
 14.0.0-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.0-powerpc64-ibm-aix-7.2.tar.xz
 14.0.0-powerpc64le-linux/arch/0 -> clang+llvm-14.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -1536,6 +1578,7 @@
 14.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 14.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 14.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+14.0.0-x86_64-linux/void/0 -> clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 14.0.0-x86_64-linux/wolfi/0 -> clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 14.0.1-aarch64-linux/amzn/0 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
 14.0.1-aarch64-linux/arch/0 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
@@ -1568,6 +1611,7 @@
 14.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
 14.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
 14.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
+14.0.1-aarch64-linux/void/0 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
 14.0.1-aarch64-linux/wolfi/0 -> clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz
 14.0.1-armv7a-linux/arch/0 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
 14.0.1-armv7a-linux/centos/6 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -1592,6 +1636,7 @@
 14.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
 14.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
 14.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
+14.0.1-armv7a-linux/void/0 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
 14.0.1-armv7a-linux/wolfi/0 -> clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz
 14.0.1-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.1-powerpc64-ibm-aix-7.2.tar.xz
 14.0.1-powerpc64le-linux/arch/0 -> clang+llvm-14.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -1652,6 +1697,7 @@
 14.0.2-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.2-aarch64-linux-gnu.tar.xz
 14.0.2-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.2-aarch64-linux-gnu.tar.xz
 14.0.2-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.2-aarch64-linux-gnu.tar.xz
+14.0.2-aarch64-linux/void/0 -> clang+llvm-14.0.2-aarch64-linux-gnu.tar.xz
 14.0.2-aarch64-linux/wolfi/0 -> clang+llvm-14.0.2-aarch64-linux-gnu.tar.xz
 14.0.2-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.2-powerpc64-ibm-aix-7.2.tar.xz
 14.0.2-x86_64-darwin/darwin/ -> clang+llvm-14.0.2-x86_64-apple-darwin.tar.xz
@@ -1688,6 +1734,7 @@
 14.0.3-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.3-aarch64-linux-gnu.tar.xz
 14.0.3-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.3-aarch64-linux-gnu.tar.xz
 14.0.3-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.3-aarch64-linux-gnu.tar.xz
+14.0.3-aarch64-linux/void/0 -> clang+llvm-14.0.3-aarch64-linux-gnu.tar.xz
 14.0.3-aarch64-linux/wolfi/0 -> clang+llvm-14.0.3-aarch64-linux-gnu.tar.xz
 14.0.3-armv7a-linux/arch/0 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
 14.0.3-armv7a-linux/centos/6 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
@@ -1712,6 +1759,7 @@
 14.0.3-armv7a-linux/ubuntu/20.10 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
 14.0.3-armv7a-linux/ubuntu/22.04 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
 14.0.3-armv7a-linux/ubuntu/24.04 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
+14.0.3-armv7a-linux/void/0 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
 14.0.3-armv7a-linux/wolfi/0 -> clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz
 14.0.3-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.3-powerpc64-ibm-aix-7.2.tar.xz
 14.0.3-powerpc64le-linux/arch/0 -> clang+llvm-14.0.3-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -1769,6 +1817,7 @@
 14.0.4-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.4-aarch64-linux-gnu.tar.xz
 14.0.4-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.4-aarch64-linux-gnu.tar.xz
 14.0.4-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.4-aarch64-linux-gnu.tar.xz
+14.0.4-aarch64-linux/void/0 -> clang+llvm-14.0.4-aarch64-linux-gnu.tar.xz
 14.0.4-aarch64-linux/wolfi/0 -> clang+llvm-14.0.4-aarch64-linux-gnu.tar.xz
 14.0.4-armv7a-linux/arch/0 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
 14.0.4-armv7a-linux/centos/6 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
@@ -1793,6 +1842,7 @@
 14.0.4-armv7a-linux/ubuntu/20.10 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
 14.0.4-armv7a-linux/ubuntu/22.04 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
 14.0.4-armv7a-linux/ubuntu/24.04 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
+14.0.4-armv7a-linux/void/0 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
 14.0.4-armv7a-linux/wolfi/0 -> clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz
 14.0.4-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.4-powerpc64-ibm-aix-7.2.tar.xz
 14.0.4-powerpc64le-linux/arch/0 -> clang+llvm-14.0.4-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -1850,6 +1900,7 @@
 14.0.5-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.5-aarch64-linux-gnu.tar.xz
 14.0.5-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.5-aarch64-linux-gnu.tar.xz
 14.0.5-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.5-aarch64-linux-gnu.tar.xz
+14.0.5-aarch64-linux/void/0 -> clang+llvm-14.0.5-aarch64-linux-gnu.tar.xz
 14.0.5-aarch64-linux/wolfi/0 -> clang+llvm-14.0.5-aarch64-linux-gnu.tar.xz
 14.0.5-armv7a-linux/arch/0 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
 14.0.5-armv7a-linux/centos/6 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
@@ -1874,6 +1925,7 @@
 14.0.5-armv7a-linux/ubuntu/20.10 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
 14.0.5-armv7a-linux/ubuntu/22.04 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
 14.0.5-armv7a-linux/ubuntu/24.04 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
+14.0.5-armv7a-linux/void/0 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
 14.0.5-armv7a-linux/wolfi/0 -> clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz
 14.0.5-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.5-powerpc64-ibm-aix-7.2.tar.xz
 14.0.5-powerpc64le-linux/arch/0 -> clang+llvm-14.0.5-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -1932,6 +1984,7 @@
 14.0.6-aarch64-linux/ubuntu/20.10 -> clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
 14.0.6-aarch64-linux/ubuntu/22.04 -> clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
 14.0.6-aarch64-linux/ubuntu/24.04 -> clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
+14.0.6-aarch64-linux/void/0 -> clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
 14.0.6-aarch64-linux/wolfi/0 -> clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
 14.0.6-armv7a-linux/arch/0 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
 14.0.6-armv7a-linux/centos/6 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
@@ -1956,6 +2009,7 @@
 14.0.6-armv7a-linux/ubuntu/20.10 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
 14.0.6-armv7a-linux/ubuntu/22.04 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
 14.0.6-armv7a-linux/ubuntu/24.04 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
+14.0.6-armv7a-linux/void/0 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
 14.0.6-armv7a-linux/wolfi/0 -> clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz
 14.0.6-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-14.0.6-powerpc64-ibm-aix-7.2.tar.xz
 14.0.6-powerpc64le-linux/arch/0 -> clang+llvm-14.0.6-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -2004,6 +2058,7 @@
 14.0.6-x86_64-linux/ubuntu/20.10 -> clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz
 14.0.6-x86_64-linux/ubuntu/22.04 -> clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz
 14.0.6-x86_64-linux/ubuntu/24.04 -> clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz
+14.0.6-x86_64-linux/void/0 -> clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz
 14.0.6-x86_64-linux/wolfi/0 -> clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.0-aarch64-darwin/darwin/ -> clang+llvm-15.0.0-arm64-apple-darwin21.0.tar.xz
 15.0.0-aarch64-linux/amzn/0 -> clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz
@@ -2037,6 +2092,7 @@
 15.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz
 15.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz
 15.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz
+15.0.0-aarch64-linux/void/0 -> clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz
 15.0.0-aarch64-linux/wolfi/0 -> clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz
 15.0.0-armv7a-linux/arch/0 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
 15.0.0-armv7a-linux/centos/6 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
@@ -2061,6 +2117,7 @@
 15.0.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
 15.0.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
 15.0.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
+15.0.0-armv7a-linux/void/0 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
 15.0.0-armv7a-linux/wolfi/0 -> clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz
 15.0.0-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.0-powerpc64-ibm-aix-7.2.tar.xz
 15.0.0-powerpc64le-linux/arch/0 -> clang+llvm-15.0.0-powerpc64le-linux-ubuntu-18.04.6.tar.xz
@@ -2116,6 +2173,7 @@
 15.0.0-sparcv9-linux/ubuntu/20.10 -> clang+llvm-15.0.0-sparc64-unknown-linux-gnu.tar.xz
 15.0.0-sparcv9-linux/ubuntu/22.04 -> clang+llvm-15.0.0-sparc64-unknown-linux-gnu.tar.xz
 15.0.0-sparcv9-linux/ubuntu/24.04 -> clang+llvm-15.0.0-sparc64-unknown-linux-gnu.tar.xz
+15.0.0-sparcv9-linux/void/0 -> clang+llvm-15.0.0-sparc64-unknown-linux-gnu.tar.xz
 15.0.0-sparcv9-linux/wolfi/0 -> clang+llvm-15.0.0-sparc64-unknown-linux-gnu.tar.xz
 15.0.0-x86_64-darwin/darwin/ -> clang+llvm-15.0.0-x86_64-apple-darwin.tar.xz
 15.0.0-x86_64-linux/arch/0 -> clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
@@ -2141,6 +2199,7 @@
 15.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
+15.0.0-x86_64-linux/void/0 -> clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.0-x86_64-linux/wolfi/0 -> clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.1-aarch64-darwin/darwin/ -> clang+llvm-15.0.1-arm64-apple-darwin21.0.tar.xz
 15.0.1-aarch64-linux/amzn/0 -> clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz
@@ -2174,6 +2233,7 @@
 15.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz
 15.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz
 15.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz
+15.0.1-aarch64-linux/void/0 -> clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz
 15.0.1-aarch64-linux/wolfi/0 -> clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz
 15.0.1-armv7a-linux/arch/0 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
 15.0.1-armv7a-linux/centos/6 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
@@ -2198,6 +2258,7 @@
 15.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
 15.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
 15.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
+15.0.1-armv7a-linux/void/0 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
 15.0.1-armv7a-linux/wolfi/0 -> clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz
 15.0.1-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.1-powerpc64-ibm-aix-7.2.tar.xz
 15.0.1-powerpc64le-linux/arch/0 -> clang+llvm-15.0.1-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -2254,6 +2315,7 @@
 15.0.2-aarch64-linux/ubuntu/20.10 -> clang+llvm-15.0.2-aarch64-linux-gnu.tar.xz
 15.0.2-aarch64-linux/ubuntu/22.04 -> clang+llvm-15.0.2-aarch64-linux-gnu.tar.xz
 15.0.2-aarch64-linux/ubuntu/24.04 -> clang+llvm-15.0.2-aarch64-linux-gnu.tar.xz
+15.0.2-aarch64-linux/void/0 -> clang+llvm-15.0.2-aarch64-linux-gnu.tar.xz
 15.0.2-aarch64-linux/wolfi/0 -> clang+llvm-15.0.2-aarch64-linux-gnu.tar.xz
 15.0.2-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.2-powerpc64-ibm-aix-7.2.tar.xz
 15.0.2-powerpc64le-linux/arch/0 -> clang+llvm-15.0.2-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -2308,6 +2370,7 @@
 15.0.2-x86_64-linux/ubuntu/20.10 -> clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz
 15.0.2-x86_64-linux/ubuntu/22.04 -> clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz
 15.0.2-x86_64-linux/ubuntu/24.04 -> clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz
+15.0.2-x86_64-linux/void/0 -> clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz
 15.0.2-x86_64-linux/wolfi/0 -> clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz
 15.0.3-aarch64-darwin/darwin/ -> clang+llvm-15.0.3-arm64-apple-darwin21.0.tar.xz
 15.0.3-aarch64-linux/amzn/0 -> clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz
@@ -2341,6 +2404,7 @@
 15.0.3-aarch64-linux/ubuntu/20.10 -> clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz
 15.0.3-aarch64-linux/ubuntu/22.04 -> clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz
 15.0.3-aarch64-linux/ubuntu/24.04 -> clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz
+15.0.3-aarch64-linux/void/0 -> clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz
 15.0.3-aarch64-linux/wolfi/0 -> clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz
 15.0.3-armv7a-linux/arch/0 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
 15.0.3-armv7a-linux/centos/6 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
@@ -2365,6 +2429,7 @@
 15.0.3-armv7a-linux/ubuntu/20.10 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
 15.0.3-armv7a-linux/ubuntu/22.04 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
 15.0.3-armv7a-linux/ubuntu/24.04 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
+15.0.3-armv7a-linux/void/0 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
 15.0.3-armv7a-linux/wolfi/0 -> clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz
 15.0.3-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.3-powerpc64-ibm-aix-7.2.tar.xz
 15.0.3-powerpc64le-linux/arch/0 -> clang+llvm-15.0.3-powerpc64le-linux-ubuntu-18.04.5.tar.xz
@@ -2435,6 +2500,7 @@
 15.0.4-x86_64-linux/ubuntu/20.10 -> clang+llvm-15.0.4-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.4-x86_64-linux/ubuntu/22.04 -> clang+llvm-15.0.4-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.4-x86_64-linux/ubuntu/24.04 -> clang+llvm-15.0.4-x86_64-linux-gnu-rhel-8.4.tar.xz
+15.0.4-x86_64-linux/void/0 -> clang+llvm-15.0.4-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.4-x86_64-linux/wolfi/0 -> clang+llvm-15.0.4-x86_64-linux-gnu-rhel-8.4.tar.xz
 15.0.5-aarch64-darwin/darwin/ -> clang+llvm-15.0.5-arm64-apple-darwin21.0.tar.xz
 15.0.5-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.5-powerpc64-ibm-aix-7.2.tar.xz
@@ -2489,6 +2555,7 @@
 15.0.5-x86_64-linux/ubuntu/20.10 -> clang+llvm-15.0.5-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.5-x86_64-linux/ubuntu/22.04 -> clang+llvm-15.0.5-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.5-x86_64-linux/ubuntu/24.04 -> clang+llvm-15.0.5-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+15.0.5-x86_64-linux/void/0 -> clang+llvm-15.0.5-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.5-x86_64-linux/wolfi/0 -> clang+llvm-15.0.5-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.6-aarch64-darwin/darwin/ -> clang+llvm-15.0.6-arm64-apple-darwin21.0.tar.xz
 15.0.6-aarch64-linux/amzn/0 -> clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz
@@ -2522,6 +2589,7 @@
 15.0.6-aarch64-linux/ubuntu/20.10 -> clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz
 15.0.6-aarch64-linux/ubuntu/22.04 -> clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz
 15.0.6-aarch64-linux/ubuntu/24.04 -> clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz
+15.0.6-aarch64-linux/void/0 -> clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz
 15.0.6-aarch64-linux/wolfi/0 -> clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz
 15.0.6-armv7a-linux/arch/0 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
 15.0.6-armv7a-linux/centos/6 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
@@ -2546,6 +2614,7 @@
 15.0.6-armv7a-linux/ubuntu/20.10 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
 15.0.6-armv7a-linux/ubuntu/22.04 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
 15.0.6-armv7a-linux/ubuntu/24.04 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
+15.0.6-armv7a-linux/void/0 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
 15.0.6-armv7a-linux/wolfi/0 -> clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz
 15.0.6-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.6-powerpc64-ibm-aix-7.2.tar.xz
 15.0.6-powerpc64le-linux/arch/0 -> clang+llvm-15.0.6-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -2599,6 +2668,7 @@
 15.0.6-x86_64-linux/ubuntu/20.10 -> clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.6-x86_64-linux/ubuntu/22.04 -> clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.6-x86_64-linux/ubuntu/24.04 -> clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+15.0.6-x86_64-linux/void/0 -> clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.6-x86_64-linux/wolfi/0 -> clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 15.0.7-aarch64-darwin/darwin/ -> clang+llvm-15.0.7-arm64-apple-darwin22.0.tar.xz
 15.0.7-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-15.0.7-powerpc64-ibm-aix-7.2.tar.xz
@@ -2656,6 +2726,7 @@
 16.0.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.0-aarch64-linux-gnu.tar.xz
 16.0.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.0-aarch64-linux-gnu.tar.xz
 16.0.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.0-aarch64-linux-gnu.tar.xz
+16.0.0-aarch64-linux/void/0 -> clang+llvm-16.0.0-aarch64-linux-gnu.tar.xz
 16.0.0-aarch64-linux/wolfi/0 -> clang+llvm-16.0.0-aarch64-linux-gnu.tar.xz
 16.0.0-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-16.0.0-powerpc64-ibm-aix-7.2.tar.xz
 16.0.0-powerpc64le-linux/arch/0 -> clang+llvm-16.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz
@@ -2711,6 +2782,7 @@
 16.0.0-sparcv9-linux/ubuntu/20.10 -> clang+llvm-16.0.0-sparc64-unknown-linux-gnu.tar.xz
 16.0.0-sparcv9-linux/ubuntu/22.04 -> clang+llvm-16.0.0-sparc64-unknown-linux-gnu.tar.xz
 16.0.0-sparcv9-linux/ubuntu/24.04 -> clang+llvm-16.0.0-sparc64-unknown-linux-gnu.tar.xz
+16.0.0-sparcv9-linux/void/0 -> clang+llvm-16.0.0-sparc64-unknown-linux-gnu.tar.xz
 16.0.0-sparcv9-linux/wolfi/0 -> clang+llvm-16.0.0-sparc64-unknown-linux-gnu.tar.xz
 16.0.0-x86_64-linux/amzn/0 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 16.0.0-x86_64-linux/arch/0 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
@@ -2744,6 +2816,7 @@
 16.0.0-x86_64-linux/ubuntu/20.10 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 16.0.0-x86_64-linux/ubuntu/22.04 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 16.0.0-x86_64-linux/ubuntu/24.04 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+16.0.0-x86_64-linux/void/0 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 16.0.0-x86_64-linux/wolfi/0 -> clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 16.0.1-aarch64-darwin/darwin/ -> clang+llvm-16.0.1-arm64-apple-darwin22.0.tar.xz
 16.0.1-aarch64-linux/amzn/0 -> clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz
@@ -2777,6 +2850,7 @@
 16.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz
 16.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz
 16.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz
+16.0.1-aarch64-linux/void/0 -> clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz
 16.0.1-aarch64-linux/wolfi/0 -> clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz
 16.0.1-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-16.0.1-powerpc64-ibm-aix-7.2.tar.xz
 16.0.1-powerpc64le-linux/arch/0 -> clang+llvm-16.0.1-powerpc64le-linux-ubuntu-20.04.tar.xz
@@ -2833,6 +2907,7 @@
 16.0.2-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.2-aarch64-linux-gnu.tar.xz
 16.0.2-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.2-aarch64-linux-gnu.tar.xz
 16.0.2-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.2-aarch64-linux-gnu.tar.xz
+16.0.2-aarch64-linux/void/0 -> clang+llvm-16.0.2-aarch64-linux-gnu.tar.xz
 16.0.2-aarch64-linux/wolfi/0 -> clang+llvm-16.0.2-aarch64-linux-gnu.tar.xz
 16.0.2-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-16.0.2-powerpc64-ibm-aix-7.2.tar.xz
 16.0.2-powerpc64le-linux/rhel/0 -> clang+llvm-16.0.2-powerpc64le-linux-rhel-8.4.tar.xz
@@ -2867,6 +2942,7 @@
 16.0.2-x86_64-linux/ubuntu/20.10 -> clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.2-x86_64-linux/ubuntu/22.04 -> clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.2-x86_64-linux/ubuntu/24.04 -> clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+16.0.2-x86_64-linux/void/0 -> clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.2-x86_64-linux/wolfi/0 -> clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.3-aarch64-darwin/darwin/ -> clang+llvm-16.0.3-arm64-apple-darwin22.0.tar.xz
 16.0.3-aarch64-linux/amzn/0 -> clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz
@@ -2900,6 +2976,7 @@
 16.0.3-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz
 16.0.3-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz
 16.0.3-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz
+16.0.3-aarch64-linux/void/0 -> clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz
 16.0.3-aarch64-linux/wolfi/0 -> clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz
 16.0.3-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-16.0.3-powerpc64-ibm-aix-7.2.tar.xz
 16.0.3-powerpc64le-linux/rhel/0 -> clang+llvm-16.0.3-powerpc64le-linux-rhel-8.4.tar.xz
@@ -2933,6 +3010,7 @@
 16.0.3-x86_64-linux/ubuntu/20.10 -> clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.3-x86_64-linux/ubuntu/22.04 -> clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.3-x86_64-linux/ubuntu/24.04 -> clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+16.0.3-x86_64-linux/void/0 -> clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.3-x86_64-linux/wolfi/0 -> clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.4-aarch64-darwin/darwin/ -> clang+llvm-16.0.4-arm64-apple-darwin22.0.tar.xz
 16.0.4-aarch64-linux/amzn/0 -> clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz
@@ -2966,6 +3044,7 @@
 16.0.4-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz
 16.0.4-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz
 16.0.4-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz
+16.0.4-aarch64-linux/void/0 -> clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz
 16.0.4-aarch64-linux/wolfi/0 -> clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz
 16.0.4-armv7a-linux/arch/0 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
 16.0.4-armv7a-linux/centos/6 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
@@ -2990,6 +3069,7 @@
 16.0.4-armv7a-linux/ubuntu/20.10 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
 16.0.4-armv7a-linux/ubuntu/22.04 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
 16.0.4-armv7a-linux/ubuntu/24.04 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
+16.0.4-armv7a-linux/void/0 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
 16.0.4-armv7a-linux/wolfi/0 -> clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz
 16.0.4-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-16.0.4-powerpc64-ibm-aix-7.2.tar.xz
 16.0.4-powerpc64le-linux/rhel/0 -> clang+llvm-16.0.4-powerpc64le-linux-rhel-8.4.tar.xz
@@ -3024,6 +3104,7 @@
 16.0.4-x86_64-linux/ubuntu/20.10 -> clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.4-x86_64-linux/ubuntu/22.04 -> clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.4-x86_64-linux/ubuntu/24.04 -> clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+16.0.4-x86_64-linux/void/0 -> clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.4-x86_64-linux/wolfi/0 -> clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 16.0.5-aarch64-darwin/darwin/ -> clang+llvm-16.0.5-arm64-apple-darwin22.0.tar.xz
 16.0.5-aarch64-linux/amzn/0 -> clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz
@@ -3057,6 +3138,7 @@
 16.0.5-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz
 16.0.5-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz
 16.0.5-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz
+16.0.5-aarch64-linux/void/0 -> clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz
 16.0.5-aarch64-linux/wolfi/0 -> clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz
 16.0.5-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-16.0.5-powerpc64-ibm-aix-7.2.tar.xz
 16.0.5-powerpc64le-linux/rhel/0 -> clang+llvm-16.0.5-powerpc64le-linux-rhel-8.7.tar.xz
@@ -3092,6 +3174,7 @@
 16.0.6-aarch64-linux/ubuntu/20.10 -> clang+llvm-16.0.6-aarch64-linux-gnu.tar.xz
 16.0.6-aarch64-linux/ubuntu/22.04 -> clang+llvm-16.0.6-aarch64-linux-gnu.tar.xz
 16.0.6-aarch64-linux/ubuntu/24.04 -> clang+llvm-16.0.6-aarch64-linux-gnu.tar.xz
+16.0.6-aarch64-linux/void/0 -> clang+llvm-16.0.6-aarch64-linux-gnu.tar.xz
 16.0.6-aarch64-linux/wolfi/0 -> clang+llvm-16.0.6-aarch64-linux-gnu.tar.xz
 16.0.6-powerpc64le-linux/rhel/0 -> clang+llvm-16.0.6-powerpc64le-linux-rhel-8.7.tar.xz
 17.0.1-aarch64-darwin/darwin/ -> clang+llvm-17.0.1-arm64-apple-darwin22.0.tar.xz
@@ -3126,6 +3209,7 @@
 17.0.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-17.0.1-aarch64-linux-gnu.tar.xz
 17.0.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-17.0.1-aarch64-linux-gnu.tar.xz
 17.0.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-17.0.1-aarch64-linux-gnu.tar.xz
+17.0.1-aarch64-linux/void/0 -> clang+llvm-17.0.1-aarch64-linux-gnu.tar.xz
 17.0.1-aarch64-linux/wolfi/0 -> clang+llvm-17.0.1-aarch64-linux-gnu.tar.xz
 17.0.1-armv7a-linux/arch/0 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
 17.0.1-armv7a-linux/centos/6 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
@@ -3150,6 +3234,7 @@
 17.0.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
 17.0.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
 17.0.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
+17.0.1-armv7a-linux/void/0 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
 17.0.1-armv7a-linux/wolfi/0 -> clang+llvm-17.0.1-armv7a-linux-gnueabihf.tar.gz
 17.0.1-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-17.0.1-final_powerpc64-ibm-aix-7.2.tar.xz
 17.0.1-powerpc64le-linux/rhel/0 -> clang+llvm-17.0.1-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3185,6 +3270,7 @@
 17.0.1-sparcv9-linux/ubuntu/20.10 -> clang+llvm-17.0.1-sparc64-unknown-linux-gnu.tar.xz
 17.0.1-sparcv9-linux/ubuntu/22.04 -> clang+llvm-17.0.1-sparc64-unknown-linux-gnu.tar.xz
 17.0.1-sparcv9-linux/ubuntu/24.04 -> clang+llvm-17.0.1-sparc64-unknown-linux-gnu.tar.xz
+17.0.1-sparcv9-linux/void/0 -> clang+llvm-17.0.1-sparc64-unknown-linux-gnu.tar.xz
 17.0.1-sparcv9-linux/wolfi/0 -> clang+llvm-17.0.1-sparc64-unknown-linux-gnu.tar.xz
 17.0.1-x86_64-linux/pc-solaris/2.11 -> clang+llvm-17.0.1-amd64-pc-solaris2.11.tar.xz
 17.0.2-aarch64-darwin/darwin/ -> clang+llvm-17.0.2-arm64-apple-darwin22.0.tar.xz
@@ -3219,6 +3305,7 @@
 17.0.2-aarch64-linux/ubuntu/20.10 -> clang+llvm-17.0.2-aarch64-linux-gnu.tar.xz
 17.0.2-aarch64-linux/ubuntu/22.04 -> clang+llvm-17.0.2-aarch64-linux-gnu.tar.xz
 17.0.2-aarch64-linux/ubuntu/24.04 -> clang+llvm-17.0.2-aarch64-linux-gnu.tar.xz
+17.0.2-aarch64-linux/void/0 -> clang+llvm-17.0.2-aarch64-linux-gnu.tar.xz
 17.0.2-aarch64-linux/wolfi/0 -> clang+llvm-17.0.2-aarch64-linux-gnu.tar.xz
 17.0.2-armv7a-linux/arch/0 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
 17.0.2-armv7a-linux/centos/6 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
@@ -3243,6 +3330,7 @@
 17.0.2-armv7a-linux/ubuntu/20.10 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
 17.0.2-armv7a-linux/ubuntu/22.04 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
 17.0.2-armv7a-linux/ubuntu/24.04 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
+17.0.2-armv7a-linux/void/0 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
 17.0.2-armv7a-linux/wolfi/0 -> clang+llvm-17.0.2-armv7a-linux-gnueabihf.tar.gz
 17.0.2-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-17.0.2-powerpc64-ibm-aix-7.2.tar.xz
 17.0.2-powerpc64le-linux/rhel/0 -> clang+llvm-17.0.2-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3278,6 +3366,7 @@
 17.0.2-sparcv9-linux/ubuntu/20.10 -> clang+llvm-17.0.2-sparc64-unknown-linux-gnu.tar.xz
 17.0.2-sparcv9-linux/ubuntu/22.04 -> clang+llvm-17.0.2-sparc64-unknown-linux-gnu.tar.xz
 17.0.2-sparcv9-linux/ubuntu/24.04 -> clang+llvm-17.0.2-sparc64-unknown-linux-gnu.tar.xz
+17.0.2-sparcv9-linux/void/0 -> clang+llvm-17.0.2-sparc64-unknown-linux-gnu.tar.xz
 17.0.2-sparcv9-linux/wolfi/0 -> clang+llvm-17.0.2-sparc64-unknown-linux-gnu.tar.xz
 17.0.2-x86_64-linux/amzn/0 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.2-x86_64-linux/arch/0 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
@@ -3310,6 +3399,7 @@
 17.0.2-x86_64-linux/ubuntu/20.10 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.2-x86_64-linux/ubuntu/22.04 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.2-x86_64-linux/ubuntu/24.04 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+17.0.2-x86_64-linux/void/0 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.2-x86_64-linux/wolfi/0 -> clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.3-aarch64-darwin/darwin/ -> clang+llvm-17.0.3-arm64-apple-darwin22.0.tar.xz
 17.0.3-aarch64-linux/amzn/0 -> clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz
@@ -3343,6 +3433,7 @@
 17.0.3-aarch64-linux/ubuntu/20.10 -> clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz
 17.0.3-aarch64-linux/ubuntu/22.04 -> clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz
 17.0.3-aarch64-linux/ubuntu/24.04 -> clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz
+17.0.3-aarch64-linux/void/0 -> clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz
 17.0.3-aarch64-linux/wolfi/0 -> clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz
 17.0.3-armv7a-linux/arch/0 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
 17.0.3-armv7a-linux/centos/6 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
@@ -3367,6 +3458,7 @@
 17.0.3-armv7a-linux/ubuntu/20.10 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
 17.0.3-armv7a-linux/ubuntu/22.04 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
 17.0.3-armv7a-linux/ubuntu/24.04 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
+17.0.3-armv7a-linux/void/0 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
 17.0.3-armv7a-linux/wolfi/0 -> clang+llvm-17.0.3-armv7a-linux-gnueabihf.tar.gz
 17.0.3-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-17.0.3-powerpc64-ibm-aix-7.2.tar.xz
 17.0.3-powerpc64le-linux/rhel/0 -> clang+llvm-17.0.3-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3402,6 +3494,7 @@
 17.0.4-aarch64-linux/ubuntu/20.10 -> clang+llvm-17.0.4-aarch64-linux-gnu.tar.xz
 17.0.4-aarch64-linux/ubuntu/22.04 -> clang+llvm-17.0.4-aarch64-linux-gnu.tar.xz
 17.0.4-aarch64-linux/ubuntu/24.04 -> clang+llvm-17.0.4-aarch64-linux-gnu.tar.xz
+17.0.4-aarch64-linux/void/0 -> clang+llvm-17.0.4-aarch64-linux-gnu.tar.xz
 17.0.4-aarch64-linux/wolfi/0 -> clang+llvm-17.0.4-aarch64-linux-gnu.tar.xz
 17.0.4-armv7a-linux/arch/0 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
 17.0.4-armv7a-linux/centos/6 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
@@ -3426,6 +3519,7 @@
 17.0.4-armv7a-linux/ubuntu/20.10 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
 17.0.4-armv7a-linux/ubuntu/22.04 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
 17.0.4-armv7a-linux/ubuntu/24.04 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
+17.0.4-armv7a-linux/void/0 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
 17.0.4-armv7a-linux/wolfi/0 -> clang+llvm-17.0.4-armv7a-linux-gnueabihf.tar.gz
 17.0.4-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-17.0.4-powerpc64-ibm-aix-7.2.tar.xz
 17.0.4-powerpc64le-linux/rhel/0 -> clang+llvm-17.0.4-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3459,6 +3553,7 @@
 17.0.4-x86_64-linux/ubuntu/20.10 -> clang+llvm-17.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.4-x86_64-linux/ubuntu/22.04 -> clang+llvm-17.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.4-x86_64-linux/ubuntu/24.04 -> clang+llvm-17.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+17.0.4-x86_64-linux/void/0 -> clang+llvm-17.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.4-x86_64-linux/wolfi/0 -> clang+llvm-17.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.5-aarch64-darwin/darwin/ -> clang+llvm-17.0.5-arm64-apple-darwin22.0.tar.xz
 17.0.5-aarch64-linux/amzn/0 -> clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz
@@ -3492,6 +3587,7 @@
 17.0.5-aarch64-linux/ubuntu/20.10 -> clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz
 17.0.5-aarch64-linux/ubuntu/22.04 -> clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz
 17.0.5-aarch64-linux/ubuntu/24.04 -> clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz
+17.0.5-aarch64-linux/void/0 -> clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz
 17.0.5-aarch64-linux/wolfi/0 -> clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz
 17.0.5-armv7a-linux/arch/0 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
 17.0.5-armv7a-linux/centos/6 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
@@ -3516,6 +3612,7 @@
 17.0.5-armv7a-linux/ubuntu/20.10 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
 17.0.5-armv7a-linux/ubuntu/22.04 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
 17.0.5-armv7a-linux/ubuntu/24.04 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
+17.0.5-armv7a-linux/void/0 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
 17.0.5-armv7a-linux/wolfi/0 -> clang+llvm-17.0.5-armv7a-linux-gnueabihf.tar.gz
 17.0.5-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-17.0.5-powerpc64-ibm-aix-7.2.tar.xz
 17.0.5-powerpc64le-linux/rhel/0 -> clang+llvm-17.0.5-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3549,6 +3646,7 @@
 17.0.5-x86_64-linux/ubuntu/20.10 -> clang+llvm-17.0.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.5-x86_64-linux/ubuntu/22.04 -> clang+llvm-17.0.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.5-x86_64-linux/ubuntu/24.04 -> clang+llvm-17.0.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+17.0.5-x86_64-linux/void/0 -> clang+llvm-17.0.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.5-x86_64-linux/wolfi/0 -> clang+llvm-17.0.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.6-aarch64-darwin/darwin/ -> clang+llvm-17.0.6-arm64-apple-darwin22.0.tar.xz
 17.0.6-aarch64-linux/amzn/0 -> clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz
@@ -3582,6 +3680,7 @@
 17.0.6-aarch64-linux/ubuntu/20.10 -> clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz
 17.0.6-aarch64-linux/ubuntu/22.04 -> clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz
 17.0.6-aarch64-linux/ubuntu/24.04 -> clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz
+17.0.6-aarch64-linux/void/0 -> clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz
 17.0.6-aarch64-linux/wolfi/0 -> clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz
 17.0.6-armv7a-linux/arch/0 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
 17.0.6-armv7a-linux/centos/6 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
@@ -3606,6 +3705,7 @@
 17.0.6-armv7a-linux/ubuntu/20.10 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
 17.0.6-armv7a-linux/ubuntu/22.04 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
 17.0.6-armv7a-linux/ubuntu/24.04 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
+17.0.6-armv7a-linux/void/0 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
 17.0.6-armv7a-linux/wolfi/0 -> clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
 17.0.6-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-17.0.6-powerpc64-ibm-aix-7.2.tar.xz
 17.0.6-powerpc64le-linux/rhel/0 -> clang+llvm-17.0.6-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3642,6 +3742,7 @@
 17.0.6-x86_64-linux/ubuntu/20.10 -> clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.6-x86_64-linux/ubuntu/22.04 -> clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.6-x86_64-linux/ubuntu/24.04 -> clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+17.0.6-x86_64-linux/void/0 -> clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 17.0.6-x86_64-linux/wolfi/0 -> clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz
 18.1.0-aarch64-linux/amzn/0 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
 18.1.0-aarch64-linux/arch/0 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
@@ -3674,6 +3775,7 @@
 18.1.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
 18.1.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
 18.1.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
+18.1.0-aarch64-linux/void/0 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
 18.1.0-aarch64-linux/wolfi/0 -> clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz
 18.1.0-armv7a-linux/arch/0 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
 18.1.0-armv7a-linux/centos/6 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
@@ -3698,6 +3800,7 @@
 18.1.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
 18.1.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
 18.1.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
+18.1.0-armv7a-linux/void/0 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
 18.1.0-armv7a-linux/wolfi/0 -> clang+llvm-18.1.0-armv7a-linux-gnueabihf.tar.gz
 18.1.0-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.0-powerpc64-ibm-aix-7.2.tar.xz
 18.1.0-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.0-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3733,6 +3836,7 @@
 18.1.0-sparcv9-linux/ubuntu/20.10 -> clang+llvm-18.1.0-sparcv9-unknown-linux-gnu.tar.xz
 18.1.0-sparcv9-linux/ubuntu/22.04 -> clang+llvm-18.1.0-sparcv9-unknown-linux-gnu.tar.xz
 18.1.0-sparcv9-linux/ubuntu/24.04 -> clang+llvm-18.1.0-sparcv9-unknown-linux-gnu.tar.xz
+18.1.0-sparcv9-linux/void/0 -> clang+llvm-18.1.0-sparcv9-unknown-linux-gnu.tar.xz
 18.1.0-sparcv9-linux/wolfi/0 -> clang+llvm-18.1.0-sparcv9-unknown-linux-gnu.tar.xz
 18.1.0-x86_64-linux/pc-solaris/2.11 -> clang+llvm-18.1.0-amd64-pc-solaris2.11.tar.xz
 18.1.0-x86_64-windows/windows/ -> clang+llvm-18.1.0-x86_64-pc-windows-msvc.tar.xz
@@ -3767,6 +3871,7 @@
 18.1.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.1-aarch64-linux-gnu.tar.xz
 18.1.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.1-aarch64-linux-gnu.tar.xz
 18.1.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.1-aarch64-linux-gnu.tar.xz
+18.1.1-aarch64-linux/void/0 -> clang+llvm-18.1.1-aarch64-linux-gnu.tar.xz
 18.1.1-aarch64-linux/wolfi/0 -> clang+llvm-18.1.1-aarch64-linux-gnu.tar.xz
 18.1.1-armv7a-linux/arch/0 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
 18.1.1-armv7a-linux/centos/6 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
@@ -3791,6 +3896,7 @@
 18.1.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
 18.1.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
 18.1.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
+18.1.1-armv7a-linux/void/0 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
 18.1.1-armv7a-linux/wolfi/0 -> clang+llvm-18.1.1-armv7a-linux-gnueabihf.tar.gz
 18.1.1-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.1-powerpc64-ibm-aix-7.2.tar.xz
 18.1.1-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.1-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3826,6 +3932,7 @@
 18.1.2-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.2-aarch64-linux-gnu.tar.xz
 18.1.2-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.2-aarch64-linux-gnu.tar.xz
 18.1.2-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.2-aarch64-linux-gnu.tar.xz
+18.1.2-aarch64-linux/void/0 -> clang+llvm-18.1.2-aarch64-linux-gnu.tar.xz
 18.1.2-aarch64-linux/wolfi/0 -> clang+llvm-18.1.2-aarch64-linux-gnu.tar.xz
 18.1.2-armv7a-linux/arch/0 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
 18.1.2-armv7a-linux/centos/6 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
@@ -3850,6 +3957,7 @@
 18.1.2-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
 18.1.2-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
 18.1.2-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
+18.1.2-armv7a-linux/void/0 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
 18.1.2-armv7a-linux/wolfi/0 -> clang+llvm-18.1.2-armv7a-linux-gnueabihf.tar.gz
 18.1.2-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.2-powerpc64-ibm-aix-7.2.tar.xz
 18.1.2-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.2-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3888,6 +3996,7 @@
 18.1.3-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.3-aarch64-linux-gnu.tar.xz
 18.1.3-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.3-aarch64-linux-gnu.tar.xz
 18.1.3-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.3-aarch64-linux-gnu.tar.xz
+18.1.3-aarch64-linux/void/0 -> clang+llvm-18.1.3-aarch64-linux-gnu.tar.xz
 18.1.3-aarch64-linux/wolfi/0 -> clang+llvm-18.1.3-aarch64-linux-gnu.tar.xz
 18.1.3-armv7a-linux/arch/0 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
 18.1.3-armv7a-linux/centos/6 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
@@ -3912,6 +4021,7 @@
 18.1.3-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
 18.1.3-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
 18.1.3-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
+18.1.3-armv7a-linux/void/0 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
 18.1.3-armv7a-linux/wolfi/0 -> clang+llvm-18.1.3-armv7a-linux-gnueabihf.tar.gz
 18.1.3-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.3-powerpc64-ibm-aix-7.2.tar.xz
 18.1.3-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.3-powerpc64le-linux-rhel-8.8.tar.xz
@@ -3946,6 +4056,7 @@
 18.1.4-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.4-aarch64-linux-gnu.tar.xz
 18.1.4-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.4-aarch64-linux-gnu.tar.xz
 18.1.4-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.4-aarch64-linux-gnu.tar.xz
+18.1.4-aarch64-linux/void/0 -> clang+llvm-18.1.4-aarch64-linux-gnu.tar.xz
 18.1.4-aarch64-linux/wolfi/0 -> clang+llvm-18.1.4-aarch64-linux-gnu.tar.xz
 18.1.4-armv7a-linux/arch/0 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
 18.1.4-armv7a-linux/centos/6 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
@@ -3970,6 +4081,7 @@
 18.1.4-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
 18.1.4-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
 18.1.4-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
+18.1.4-armv7a-linux/void/0 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
 18.1.4-armv7a-linux/wolfi/0 -> clang+llvm-18.1.4-armv7a-linux-gnueabihf.tar.gz
 18.1.4-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.4-powerpc64-ibm-aix-7.2.tar.xz
 18.1.4-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.4-powerpc64le-linux-rhel-8.8.tar.xz
@@ -4003,6 +4115,7 @@
 18.1.4-x86_64-linux/ubuntu/20.10 -> clang+llvm-18.1.4-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.4-x86_64-linux/ubuntu/22.04 -> clang+llvm-18.1.4-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.4-x86_64-linux/ubuntu/24.04 -> clang+llvm-18.1.4-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+18.1.4-x86_64-linux/void/0 -> clang+llvm-18.1.4-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.4-x86_64-linux/wolfi/0 -> clang+llvm-18.1.4-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.4-x86_64-windows/windows/ -> clang+llvm-18.1.4-x86_64-pc-windows-msvc.tar.xz
 18.1.5-aarch64-linux/amzn/0 -> clang+llvm-18.1.5-aarch64-linux-gnu.tar.xz
@@ -4036,6 +4149,7 @@
 18.1.5-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.5-aarch64-linux-gnu.tar.xz
 18.1.5-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.5-aarch64-linux-gnu.tar.xz
 18.1.5-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.5-aarch64-linux-gnu.tar.xz
+18.1.5-aarch64-linux/void/0 -> clang+llvm-18.1.5-aarch64-linux-gnu.tar.xz
 18.1.5-aarch64-linux/wolfi/0 -> clang+llvm-18.1.5-aarch64-linux-gnu.tar.xz
 18.1.5-armv7a-linux/arch/0 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
 18.1.5-armv7a-linux/centos/6 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
@@ -4060,6 +4174,7 @@
 18.1.5-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
 18.1.5-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
 18.1.5-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
+18.1.5-armv7a-linux/void/0 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
 18.1.5-armv7a-linux/wolfi/0 -> clang+llvm-18.1.5-armv7a-linux-gnueabihf.tar.gz
 18.1.5-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.5-powerpc64-ibm-aix-7.2.tar.xz
 18.1.5-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.5-powerpc64le-linux-rhel-8.8.tar.xz
@@ -4095,6 +4210,7 @@
 18.1.6-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.6-aarch64-linux-gnu.tar.xz
 18.1.6-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.6-aarch64-linux-gnu.tar.xz
 18.1.6-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.6-aarch64-linux-gnu.tar.xz
+18.1.6-aarch64-linux/void/0 -> clang+llvm-18.1.6-aarch64-linux-gnu.tar.xz
 18.1.6-aarch64-linux/wolfi/0 -> clang+llvm-18.1.6-aarch64-linux-gnu.tar.xz
 18.1.6-armv7a-linux/arch/0 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
 18.1.6-armv7a-linux/centos/6 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
@@ -4119,6 +4235,7 @@
 18.1.6-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
 18.1.6-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
 18.1.6-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
+18.1.6-armv7a-linux/void/0 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
 18.1.6-armv7a-linux/wolfi/0 -> clang+llvm-18.1.6-armv7a-linux-gnueabihf.tar.gz
 18.1.6-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.6-powerpc64le-linux-rhel-8.8.tar.xz
 18.1.6-sparc64-linux/sun-solaris/2.11 -> clang+llvm-18.1.6-sparcv9-sun-solaris2.11.tar.xz
@@ -4156,6 +4273,7 @@
 18.1.7-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.7-aarch64-linux-gnu.tar.xz
 18.1.7-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.7-aarch64-linux-gnu.tar.xz
 18.1.7-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.7-aarch64-linux-gnu.tar.xz
+18.1.7-aarch64-linux/void/0 -> clang+llvm-18.1.7-aarch64-linux-gnu.tar.xz
 18.1.7-aarch64-linux/wolfi/0 -> clang+llvm-18.1.7-aarch64-linux-gnu.tar.xz
 18.1.7-armv7a-linux/arch/0 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
 18.1.7-armv7a-linux/centos/6 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
@@ -4180,6 +4298,7 @@
 18.1.7-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
 18.1.7-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
 18.1.7-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
+18.1.7-armv7a-linux/void/0 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
 18.1.7-armv7a-linux/wolfi/0 -> clang+llvm-18.1.7-armv7a-linux-gnueabihf.tar.gz
 18.1.7-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.7-powerpc64-ibm-aix-7.2.tar.xz
 18.1.7-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.7-powerpc64le-linux-rhel-8.8.tar.xz
@@ -4213,6 +4332,7 @@
 18.1.7-x86_64-linux/ubuntu/20.10 -> clang+llvm-18.1.7-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.7-x86_64-linux/ubuntu/22.04 -> clang+llvm-18.1.7-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.7-x86_64-linux/ubuntu/24.04 -> clang+llvm-18.1.7-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+18.1.7-x86_64-linux/void/0 -> clang+llvm-18.1.7-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.7-x86_64-linux/wolfi/0 -> clang+llvm-18.1.7-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.7-x86_64-windows/windows/ -> clang+llvm-18.1.7-x86_64-pc-windows-msvc.tar.xz
 18.1.8-aarch64-darwin/darwin/ -> clang+llvm-18.1.8-arm64-apple-macos11.tar.xz
@@ -4247,6 +4367,7 @@
 18.1.8-aarch64-linux/ubuntu/20.10 -> clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz
 18.1.8-aarch64-linux/ubuntu/22.04 -> clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz
 18.1.8-aarch64-linux/ubuntu/24.04 -> clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz
+18.1.8-aarch64-linux/void/0 -> clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz
 18.1.8-aarch64-linux/wolfi/0 -> clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz
 18.1.8-armv7a-linux/arch/0 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
 18.1.8-armv7a-linux/centos/6 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
@@ -4271,6 +4392,7 @@
 18.1.8-armv7a-linux/ubuntu/20.10 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
 18.1.8-armv7a-linux/ubuntu/22.04 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
 18.1.8-armv7a-linux/ubuntu/24.04 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
+18.1.8-armv7a-linux/void/0 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
 18.1.8-armv7a-linux/wolfi/0 -> clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz
 18.1.8-powerpc64-linux/ibm-aix/7.2 -> clang+llvm-18.1.8-powerpc64-ibm-aix-7.2.tar.xz
 18.1.8-powerpc64le-linux/rhel/0 -> clang+llvm-18.1.8-powerpc64le-linux-rhel-8.8.tar.xz
@@ -4304,6 +4426,7 @@
 18.1.8-x86_64-linux/ubuntu/20.10 -> clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.8-x86_64-linux/ubuntu/22.04 -> clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.8-x86_64-linux/ubuntu/24.04 -> clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+18.1.8-x86_64-linux/void/0 -> clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.8-x86_64-linux/wolfi/0 -> clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 18.1.8-x86_64-windows/windows/ -> clang+llvm-18.1.8-x86_64-pc-windows-msvc.tar.xz
 19.1.0-aarch64-darwin/darwin/ -> LLVM-19.1.0-macOS-ARM64.tar.xz
@@ -4338,6 +4461,7 @@
 19.1.0-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.0-aarch64-linux-gnu.tar.xz
 19.1.0-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.0-aarch64-linux-gnu.tar.xz
 19.1.0-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.0-aarch64-linux-gnu.tar.xz
+19.1.0-aarch64-linux/void/0 -> clang+llvm-19.1.0-aarch64-linux-gnu.tar.xz
 19.1.0-aarch64-linux/wolfi/0 -> clang+llvm-19.1.0-aarch64-linux-gnu.tar.xz
 19.1.0-armv7a-linux/arch/0 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
 19.1.0-armv7a-linux/centos/6 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
@@ -4362,6 +4486,7 @@
 19.1.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
 19.1.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
 19.1.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
+19.1.0-armv7a-linux/void/0 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
 19.1.0-armv7a-linux/wolfi/0 -> clang+llvm-19.1.0-armv7a-linux-gnueabihf.tar.gz
 19.1.0-x86_64-darwin/darwin/ -> LLVM-19.1.0-macOS-X64.tar.xz
 19.1.0-x86_64-linux/amzn/0 -> LLVM-19.1.0-Linux-X64.tar.xz
@@ -4399,6 +4524,7 @@
 19.1.0-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.0-Linux-X64.tar.xz
 19.1.0-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.0-Linux-X64.tar.xz
 19.1.0-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.0-Linux-X64.tar.xz
+19.1.0-x86_64-linux/void/0 -> LLVM-19.1.0-Linux-X64.tar.xz
 19.1.0-x86_64-linux/wolfi/0 -> LLVM-19.1.0-Linux-X64.tar.xz
 19.1.0-x86_64-windows/windows/ -> LLVM-19.1.0-Windows-X64.tar.xz
 19.1.1-aarch64-darwin/darwin/ -> LLVM-19.1.1-macOS-ARM64.tar.xz
@@ -4433,6 +4559,7 @@
 19.1.1-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.1-aarch64-linux-gnu.tar.xz
 19.1.1-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.1-aarch64-linux-gnu.tar.xz
 19.1.1-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.1-aarch64-linux-gnu.tar.xz
+19.1.1-aarch64-linux/void/0 -> clang+llvm-19.1.1-aarch64-linux-gnu.tar.xz
 19.1.1-aarch64-linux/wolfi/0 -> clang+llvm-19.1.1-aarch64-linux-gnu.tar.xz
 19.1.1-armv7a-linux/arch/0 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
 19.1.1-armv7a-linux/centos/6 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
@@ -4457,6 +4584,7 @@
 19.1.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
 19.1.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
 19.1.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
+19.1.1-armv7a-linux/void/0 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
 19.1.1-armv7a-linux/wolfi/0 -> clang+llvm-19.1.1-armv7a-linux-gnueabihf.tar.gz
 19.1.1-x86_64-linux/amzn/0 -> LLVM-19.1.1-Linux-X64.tar.xz
 19.1.1-x86_64-linux/arch/0 -> LLVM-19.1.1-Linux-X64.tar.xz
@@ -4493,6 +4621,7 @@
 19.1.1-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.1-Linux-X64.tar.xz
 19.1.1-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.1-Linux-X64.tar.xz
 19.1.1-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.1-Linux-X64.tar.xz
+19.1.1-x86_64-linux/void/0 -> LLVM-19.1.1-Linux-X64.tar.xz
 19.1.1-x86_64-linux/wolfi/0 -> LLVM-19.1.1-Linux-X64.tar.xz
 19.1.1-x86_64-windows/windows/ -> LLVM-19.1.1-Windows-X64.tar.xz
 19.1.2-aarch64-darwin/darwin/ -> LLVM-19.1.2-macOS-ARM64.tar.xz
@@ -4527,6 +4656,7 @@
 19.1.2-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.2-aarch64-linux-gnu.tar.xz
 19.1.2-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.2-aarch64-linux-gnu.tar.xz
 19.1.2-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.2-aarch64-linux-gnu.tar.xz
+19.1.2-aarch64-linux/void/0 -> clang+llvm-19.1.2-aarch64-linux-gnu.tar.xz
 19.1.2-aarch64-linux/wolfi/0 -> clang+llvm-19.1.2-aarch64-linux-gnu.tar.xz
 19.1.2-armv7a-linux/arch/0 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
 19.1.2-armv7a-linux/centos/6 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
@@ -4551,6 +4681,7 @@
 19.1.2-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
 19.1.2-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
 19.1.2-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
+19.1.2-armv7a-linux/void/0 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
 19.1.2-armv7a-linux/wolfi/0 -> clang+llvm-19.1.2-armv7a-linux-gnueabihf.tar.gz
 19.1.2-x86_64-linux/amzn/0 -> LLVM-19.1.2-Linux-X64.tar.xz
 19.1.2-x86_64-linux/arch/0 -> LLVM-19.1.2-Linux-X64.tar.xz
@@ -4587,6 +4718,7 @@
 19.1.2-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.2-Linux-X64.tar.xz
 19.1.2-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.2-Linux-X64.tar.xz
 19.1.2-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.2-Linux-X64.tar.xz
+19.1.2-x86_64-linux/void/0 -> LLVM-19.1.2-Linux-X64.tar.xz
 19.1.2-x86_64-linux/wolfi/0 -> LLVM-19.1.2-Linux-X64.tar.xz
 19.1.2-x86_64-windows/windows/ -> LLVM-19.1.2-Windows-X64.tar.xz
 19.1.3-aarch64-darwin/darwin/ -> LLVM-19.1.3-macOS-ARM64.tar.xz
@@ -4621,6 +4753,7 @@
 19.1.3-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.3-aarch64-linux-gnu.tar.xz
 19.1.3-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.3-aarch64-linux-gnu.tar.xz
 19.1.3-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.3-aarch64-linux-gnu.tar.xz
+19.1.3-aarch64-linux/void/0 -> clang+llvm-19.1.3-aarch64-linux-gnu.tar.xz
 19.1.3-aarch64-linux/wolfi/0 -> clang+llvm-19.1.3-aarch64-linux-gnu.tar.xz
 19.1.3-armv7a-linux/arch/0 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
 19.1.3-armv7a-linux/centos/6 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
@@ -4645,6 +4778,7 @@
 19.1.3-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
 19.1.3-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
 19.1.3-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
+19.1.3-armv7a-linux/void/0 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
 19.1.3-armv7a-linux/wolfi/0 -> clang+llvm-19.1.3-armv7a-linux-gnueabihf.tar.gz
 19.1.3-x86_64-darwin/darwin/ -> LLVM-19.1.3-macOS-X64.tar.xz
 19.1.3-x86_64-linux/amzn/0 -> LLVM-19.1.3-Linux-X64.tar.xz
@@ -4682,6 +4816,7 @@
 19.1.3-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.3-Linux-X64.tar.xz
 19.1.3-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.3-Linux-X64.tar.xz
 19.1.3-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.3-Linux-X64.tar.xz
+19.1.3-x86_64-linux/void/0 -> LLVM-19.1.3-Linux-X64.tar.xz
 19.1.3-x86_64-linux/wolfi/0 -> LLVM-19.1.3-Linux-X64.tar.xz
 19.1.3-x86_64-windows/windows/ -> LLVM-19.1.3-Windows-X64.tar.xz
 19.1.4-aarch64-darwin/darwin/ -> LLVM-19.1.4-macOS-ARM64.tar.xz
@@ -4716,6 +4851,7 @@
 19.1.4-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.4-aarch64-linux-gnu.tar.xz
 19.1.4-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.4-aarch64-linux-gnu.tar.xz
 19.1.4-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.4-aarch64-linux-gnu.tar.xz
+19.1.4-aarch64-linux/void/0 -> clang+llvm-19.1.4-aarch64-linux-gnu.tar.xz
 19.1.4-aarch64-linux/wolfi/0 -> clang+llvm-19.1.4-aarch64-linux-gnu.tar.xz
 19.1.4-armv7a-linux/arch/0 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
 19.1.4-armv7a-linux/centos/6 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
@@ -4740,6 +4876,7 @@
 19.1.4-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
 19.1.4-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
 19.1.4-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
+19.1.4-armv7a-linux/void/0 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
 19.1.4-armv7a-linux/wolfi/0 -> clang+llvm-19.1.4-armv7a-linux-gnueabihf.tar.gz
 19.1.4-x86_64-darwin/darwin/ -> LLVM-19.1.4-macOS-X64.tar.xz
 19.1.4-x86_64-linux/amzn/0 -> LLVM-19.1.4-Linux-X64.tar.xz
@@ -4777,6 +4914,7 @@
 19.1.4-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.4-Linux-X64.tar.xz
 19.1.4-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.4-Linux-X64.tar.xz
 19.1.4-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.4-Linux-X64.tar.xz
+19.1.4-x86_64-linux/void/0 -> LLVM-19.1.4-Linux-X64.tar.xz
 19.1.4-x86_64-linux/wolfi/0 -> LLVM-19.1.4-Linux-X64.tar.xz
 19.1.4-x86_64-windows/windows/ -> clang+llvm-19.1.4-x86_64-pc-windows-msvc.tar.xz
 19.1.5-aarch64-linux/amzn/0 -> clang+llvm-19.1.5-aarch64-linux-gnu.tar.xz
@@ -4810,6 +4948,7 @@
 19.1.5-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.5-aarch64-linux-gnu.tar.xz
 19.1.5-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.5-aarch64-linux-gnu.tar.xz
 19.1.5-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.5-aarch64-linux-gnu.tar.xz
+19.1.5-aarch64-linux/void/0 -> clang+llvm-19.1.5-aarch64-linux-gnu.tar.xz
 19.1.5-aarch64-linux/wolfi/0 -> clang+llvm-19.1.5-aarch64-linux-gnu.tar.xz
 19.1.5-armv7a-linux/arch/0 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
 19.1.5-armv7a-linux/centos/6 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
@@ -4834,6 +4973,7 @@
 19.1.5-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
 19.1.5-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
 19.1.5-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
+19.1.5-armv7a-linux/void/0 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
 19.1.5-armv7a-linux/wolfi/0 -> clang+llvm-19.1.5-armv7a-linux-gnueabihf.tar.gz
 19.1.5-x86_64-darwin/darwin/ -> LLVM-19.1.5-macOS-X64.tar.xz
 19.1.5-x86_64-linux/amzn/0 -> LLVM-19.1.5-Linux-X64.tar.xz
@@ -4871,6 +5011,7 @@
 19.1.5-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.5-Linux-X64.tar.xz
 19.1.5-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.5-Linux-X64.tar.xz
 19.1.5-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.5-Linux-X64.tar.xz
+19.1.5-x86_64-linux/void/0 -> LLVM-19.1.5-Linux-X64.tar.xz
 19.1.5-x86_64-linux/wolfi/0 -> LLVM-19.1.5-Linux-X64.tar.xz
 19.1.5-x86_64-windows/windows/ -> clang+llvm-19.1.5-x86_64-pc-windows-msvc.tar.xz
 19.1.6-aarch64-darwin/darwin/ -> LLVM-19.1.6-macOS-ARM64.tar.xz
@@ -4905,6 +5046,7 @@
 19.1.6-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz
 19.1.6-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz
 19.1.6-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz
+19.1.6-aarch64-linux/void/0 -> clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz
 19.1.6-aarch64-linux/wolfi/0 -> clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz
 19.1.6-armv7a-linux/arch/0 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
 19.1.6-armv7a-linux/centos/6 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
@@ -4929,6 +5071,7 @@
 19.1.6-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
 19.1.6-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
 19.1.6-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
+19.1.6-armv7a-linux/void/0 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
 19.1.6-armv7a-linux/wolfi/0 -> clang+llvm-19.1.6-armv7a-linux-gnueabihf.tar.gz
 19.1.6-x86_64-darwin/darwin/ -> LLVM-19.1.6-macOS-X64.tar.xz
 19.1.6-x86_64-linux/amzn/0 -> LLVM-19.1.6-Linux-X64.tar.xz
@@ -4966,6 +5109,7 @@
 19.1.6-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.6-Linux-X64.tar.xz
 19.1.6-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.6-Linux-X64.tar.xz
 19.1.6-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.6-Linux-X64.tar.xz
+19.1.6-x86_64-linux/void/0 -> LLVM-19.1.6-Linux-X64.tar.xz
 19.1.6-x86_64-linux/wolfi/0 -> LLVM-19.1.6-Linux-X64.tar.xz
 19.1.6-x86_64-windows/windows/ -> clang+llvm-19.1.6-x86_64-pc-windows-msvc.tar.xz
 19.1.7-aarch64-darwin/darwin/ -> LLVM-19.1.7-macOS-ARM64.tar.xz
@@ -5000,6 +5144,7 @@
 19.1.7-aarch64-linux/ubuntu/20.10 -> clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz
 19.1.7-aarch64-linux/ubuntu/22.04 -> clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz
 19.1.7-aarch64-linux/ubuntu/24.04 -> clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz
+19.1.7-aarch64-linux/void/0 -> clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz
 19.1.7-aarch64-linux/wolfi/0 -> clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz
 19.1.7-armv7a-linux/arch/0 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
 19.1.7-armv7a-linux/centos/6 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
@@ -5024,6 +5169,7 @@
 19.1.7-armv7a-linux/ubuntu/20.10 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
 19.1.7-armv7a-linux/ubuntu/22.04 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
 19.1.7-armv7a-linux/ubuntu/24.04 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
+19.1.7-armv7a-linux/void/0 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
 19.1.7-armv7a-linux/wolfi/0 -> clang+llvm-19.1.7-armv7a-linux-gnueabihf.tar.gz
 19.1.7-x86_64-darwin/darwin/ -> LLVM-19.1.7-macOS-X64.tar.xz
 19.1.7-x86_64-linux/amzn/0 -> LLVM-19.1.7-Linux-X64.tar.xz
@@ -5061,6 +5207,7 @@
 19.1.7-x86_64-linux/ubuntu/20.10 -> LLVM-19.1.7-Linux-X64.tar.xz
 19.1.7-x86_64-linux/ubuntu/22.04 -> LLVM-19.1.7-Linux-X64.tar.xz
 19.1.7-x86_64-linux/ubuntu/24.04 -> LLVM-19.1.7-Linux-X64.tar.xz
+19.1.7-x86_64-linux/void/0 -> LLVM-19.1.7-Linux-X64.tar.xz
 19.1.7-x86_64-linux/wolfi/0 -> LLVM-19.1.7-Linux-X64.tar.xz
 19.1.7-x86_64-windows/windows/ -> clang+llvm-19.1.7-x86_64-pc-windows-msvc.tar.xz
 20.1.0-aarch64-darwin/darwin/ -> LLVM-20.1.0-macOS-ARM64.tar.xz
@@ -5099,6 +5246,7 @@
 20.1.0-aarch64-linux/ubuntu/20.10 -> LLVM-20.1.0-Linux-ARM64.tar.xz
 20.1.0-aarch64-linux/ubuntu/22.04 -> LLVM-20.1.0-Linux-ARM64.tar.xz
 20.1.0-aarch64-linux/ubuntu/24.04 -> LLVM-20.1.0-Linux-ARM64.tar.xz
+20.1.0-aarch64-linux/void/0 -> LLVM-20.1.0-Linux-ARM64.tar.xz
 20.1.0-aarch64-linux/wolfi/0 -> LLVM-20.1.0-Linux-ARM64.tar.xz
 20.1.0-aarch64-windows/windows/ -> clang+llvm-20.1.0-aarch64-pc-windows-msvc.tar.xz
 20.1.0-armv7a-linux/arch/0 -> clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz
@@ -5124,6 +5272,7 @@
 20.1.0-armv7a-linux/ubuntu/20.10 -> clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz
 20.1.0-armv7a-linux/ubuntu/22.04 -> clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz
 20.1.0-armv7a-linux/ubuntu/24.04 -> clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz
+20.1.0-armv7a-linux/void/0 -> clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz
 20.1.0-armv7a-linux/wolfi/0 -> clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz
 20.1.0-x86_64-linux/amzn/0 -> LLVM-20.1.0-Linux-X64.tar.xz
 20.1.0-x86_64-linux/arch/0 -> LLVM-20.1.0-Linux-X64.tar.xz
@@ -5160,6 +5309,7 @@
 20.1.0-x86_64-linux/ubuntu/20.10 -> LLVM-20.1.0-Linux-X64.tar.xz
 20.1.0-x86_64-linux/ubuntu/22.04 -> LLVM-20.1.0-Linux-X64.tar.xz
 20.1.0-x86_64-linux/ubuntu/24.04 -> LLVM-20.1.0-Linux-X64.tar.xz
+20.1.0-x86_64-linux/void/0 -> LLVM-20.1.0-Linux-X64.tar.xz
 20.1.0-x86_64-linux/wolfi/0 -> LLVM-20.1.0-Linux-X64.tar.xz
 20.1.0-x86_64-windows/windows/ -> clang+llvm-20.1.0-x86_64-pc-windows-msvc.tar.xz
 20.1.1-aarch64-darwin/darwin/ -> LLVM-20.1.1-macOS-ARM64.tar.xz
@@ -5198,6 +5348,7 @@
 20.1.1-aarch64-linux/ubuntu/20.10 -> LLVM-20.1.1-Linux-ARM64.tar.xz
 20.1.1-aarch64-linux/ubuntu/22.04 -> LLVM-20.1.1-Linux-ARM64.tar.xz
 20.1.1-aarch64-linux/ubuntu/24.04 -> LLVM-20.1.1-Linux-ARM64.tar.xz
+20.1.1-aarch64-linux/void/0 -> LLVM-20.1.1-Linux-ARM64.tar.xz
 20.1.1-aarch64-linux/wolfi/0 -> LLVM-20.1.1-Linux-ARM64.tar.xz
 20.1.1-aarch64-windows/windows/ -> clang+llvm-20.1.1-aarch64-pc-windows-msvc.tar.xz
 20.1.1-armv7a-linux/arch/0 -> clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz
@@ -5223,6 +5374,7 @@
 20.1.1-armv7a-linux/ubuntu/20.10 -> clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz
 20.1.1-armv7a-linux/ubuntu/22.04 -> clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz
 20.1.1-armv7a-linux/ubuntu/24.04 -> clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz
+20.1.1-armv7a-linux/void/0 -> clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz
 20.1.1-armv7a-linux/wolfi/0 -> clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz
 20.1.1-x86_64-linux/amzn/0 -> LLVM-20.1.1-Linux-X64.tar.xz
 20.1.1-x86_64-linux/arch/0 -> LLVM-20.1.1-Linux-X64.tar.xz
@@ -5259,6 +5411,7 @@
 20.1.1-x86_64-linux/ubuntu/20.10 -> LLVM-20.1.1-Linux-X64.tar.xz
 20.1.1-x86_64-linux/ubuntu/22.04 -> LLVM-20.1.1-Linux-X64.tar.xz
 20.1.1-x86_64-linux/ubuntu/24.04 -> LLVM-20.1.1-Linux-X64.tar.xz
+20.1.1-x86_64-linux/void/0 -> LLVM-20.1.1-Linux-X64.tar.xz
 20.1.1-x86_64-linux/wolfi/0 -> LLVM-20.1.1-Linux-X64.tar.xz
 20.1.1-x86_64-windows/windows/ -> clang+llvm-20.1.1-x86_64-pc-windows-msvc.tar.xz
 20.1.2-aarch64-darwin/darwin/ -> LLVM-20.1.2-macOS-ARM64.tar.xz
@@ -5297,6 +5450,7 @@
 20.1.2-aarch64-linux/ubuntu/20.10 -> LLVM-20.1.2-Linux-ARM64.tar.xz
 20.1.2-aarch64-linux/ubuntu/22.04 -> LLVM-20.1.2-Linux-ARM64.tar.xz
 20.1.2-aarch64-linux/ubuntu/24.04 -> LLVM-20.1.2-Linux-ARM64.tar.xz
+20.1.2-aarch64-linux/void/0 -> LLVM-20.1.2-Linux-ARM64.tar.xz
 20.1.2-aarch64-linux/wolfi/0 -> LLVM-20.1.2-Linux-ARM64.tar.xz
 20.1.2-aarch64-windows/windows/ -> clang+llvm-20.1.2-aarch64-pc-windows-msvc.tar.xz
 20.1.2-armv7a-linux/arch/0 -> clang+llvm-20.1.2-armv7a-linux-gnueabihf.tar.gz
@@ -5322,6 +5476,7 @@
 20.1.2-armv7a-linux/ubuntu/20.10 -> clang+llvm-20.1.2-armv7a-linux-gnueabihf.tar.gz
 20.1.2-armv7a-linux/ubuntu/22.04 -> clang+llvm-20.1.2-armv7a-linux-gnueabihf.tar.gz
 20.1.2-armv7a-linux/ubuntu/24.04 -> clang+llvm-20.1.2-armv7a-linux-gnueabihf.tar.gz
+20.1.2-armv7a-linux/void/0 -> clang+llvm-20.1.2-armv7a-linux-gnueabihf.tar.gz
 20.1.2-armv7a-linux/wolfi/0 -> clang+llvm-20.1.2-armv7a-linux-gnueabihf.tar.gz
 20.1.2-x86_64-linux/amzn/0 -> LLVM-20.1.2-Linux-X64.tar.xz
 20.1.2-x86_64-linux/arch/0 -> LLVM-20.1.2-Linux-X64.tar.xz
@@ -5358,6 +5513,7 @@
 20.1.2-x86_64-linux/ubuntu/20.10 -> LLVM-20.1.2-Linux-X64.tar.xz
 20.1.2-x86_64-linux/ubuntu/22.04 -> LLVM-20.1.2-Linux-X64.tar.xz
 20.1.2-x86_64-linux/ubuntu/24.04 -> LLVM-20.1.2-Linux-X64.tar.xz
+20.1.2-x86_64-linux/void/0 -> LLVM-20.1.2-Linux-X64.tar.xz
 20.1.2-x86_64-linux/wolfi/0 -> LLVM-20.1.2-Linux-X64.tar.xz
 20.1.2-x86_64-windows/windows/ -> clang+llvm-20.1.2-x86_64-pc-windows-msvc.tar.xz
 20.1.3-aarch64-darwin/darwin/ -> LLVM-20.1.3-macOS-ARM64.tar.xz
@@ -5396,6 +5552,7 @@
 20.1.3-aarch64-linux/ubuntu/20.10 -> LLVM-20.1.3-Linux-ARM64.tar.xz
 20.1.3-aarch64-linux/ubuntu/22.04 -> LLVM-20.1.3-Linux-ARM64.tar.xz
 20.1.3-aarch64-linux/ubuntu/24.04 -> LLVM-20.1.3-Linux-ARM64.tar.xz
+20.1.3-aarch64-linux/void/0 -> LLVM-20.1.3-Linux-ARM64.tar.xz
 20.1.3-aarch64-linux/wolfi/0 -> LLVM-20.1.3-Linux-ARM64.tar.xz
 20.1.3-aarch64-windows/windows/ -> clang+llvm-20.1.3-aarch64-pc-windows-msvc.tar.xz
 20.1.3-armv7a-linux/arch/0 -> clang+llvm-20.1.3-armv7a-linux-gnueabihf.tar.gz
@@ -5421,6 +5578,7 @@
 20.1.3-armv7a-linux/ubuntu/20.10 -> clang+llvm-20.1.3-armv7a-linux-gnueabihf.tar.gz
 20.1.3-armv7a-linux/ubuntu/22.04 -> clang+llvm-20.1.3-armv7a-linux-gnueabihf.tar.gz
 20.1.3-armv7a-linux/ubuntu/24.04 -> clang+llvm-20.1.3-armv7a-linux-gnueabihf.tar.gz
+20.1.3-armv7a-linux/void/0 -> clang+llvm-20.1.3-armv7a-linux-gnueabihf.tar.gz
 20.1.3-armv7a-linux/wolfi/0 -> clang+llvm-20.1.3-armv7a-linux-gnueabihf.tar.gz
 20.1.3-x86_64-darwin/darwin/ -> LLVM-20.1.3-macOS-X64.tar.xz
 20.1.3-x86_64-linux/amzn/0 -> LLVM-20.1.3-Linux-X64.tar.xz
@@ -5458,5 +5616,6 @@
 20.1.3-x86_64-linux/ubuntu/20.10 -> LLVM-20.1.3-Linux-X64.tar.xz
 20.1.3-x86_64-linux/ubuntu/22.04 -> LLVM-20.1.3-Linux-X64.tar.xz
 20.1.3-x86_64-linux/ubuntu/24.04 -> LLVM-20.1.3-Linux-X64.tar.xz
+20.1.3-x86_64-linux/void/0 -> LLVM-20.1.3-Linux-X64.tar.xz
 20.1.3-x86_64-linux/wolfi/0 -> LLVM-20.1.3-Linux-X64.tar.xz
 20.1.3-x86_64-windows/windows/ -> clang+llvm-20.1.3-x86_64-pc-windows-msvc.tar.xz


### PR DESCRIPTION
Unrecognized Linux distributions (e.g., Void Linux) failed with "No matching config could be found" because `_dist_to_os_names` returned an empty list, and both the aarch64 and x86 code paths had no useful fallback. The aarch64 path short-circuited on an empty list, and the x86 path fell back to the raw distro name (e.g., "void") which never matches any LLVM distribution.

Pass `["linux-gnu", "unknown-linux-gnu"]` as the default to `_dist_to_os_names` in both code paths so unrecognized distros fall back to generic linux-gnu binaries.